### PR TITLE
Refactor variable names

### DIFF
--- a/actions_swc.py
+++ b/actions_swc.py
@@ -63,12 +63,12 @@ def createP(length, angle, p1, p2, flag): # return new pt3dadd lines formatted i
 	axis = p2-p1
 		
 	axis = axis / np.linalg.norm(axis) # normalize to a unit vector with the same direction
-	tmp = np.cross(axis, axis_origin)
-	tmp = tmp/np.linalg.norm(tmp)
-
-	xt = tmp[0,0]
-	yt = tmp[0,1]
-	zt = tmp[0,2]
+	perp_vector = np.cross(axis, axis_origin)
+	perp_vector = perp_vector/np.linalg.norm(perp_vector)
+	
+	xt = perp_vector[0,0]
+	yt = perp_vector[0,1]
+	zt = perp_vector[0,2]
 
 	r1 = np.matrix([[cos(r)+(xt**2)*(1-cos(r)), xt*yt*(1-cos(r))-zt*sin(r), xt*zt*(1-cos(r))+yt*sin(r)],
 		[yt*xt*(1-cos(r))+zt*sin(r) , cos(r) + (yt**2)*(1-cos(r)), yt*zt*(1-cos(r))-xt*sin(r)],
@@ -319,15 +319,15 @@ def shrink(who, action, amount, hm_choice, dend_add3d, dist, soma_index, points,
 			zn='%.2f' % (round_to((zp+per*zn),0.01))
 
 			segment_list.append([current_point[0], current_point[1], float(xn), float(yn), float(zn), float(dp), current_point[6]])
-			dend_add3d[dend]=mylists
+			dend_add3d[dend]=segment_list
 
 		if dend not in all_terminal:
 
 			final_position=dend_add3d[dend][-1]
 
 			vec=[initial_position[2]-final_position[2], initial_position[3]-final_position[3], initial_position[4]-final_position[4]]
-			my_vec=tuple(vec)
-			dend_add3d=transpose(my_vec, dend, descendants, dend_add3d)
+			translation_vec=tuple(vec)
+			dend_add3d=transpose(translation_vec, dend, descendants, dend_add3d)
 
 	segment_list=[]
 
@@ -640,8 +640,8 @@ def extend(who, action, amount, hm_choice, dend_add3d, dist, max_index, soma_ind
 			final_position=add_these_lines[dend][-1]
 
 			vec=[initial_position[2]-final_position[2], initial_position[3]-final_position[3], initial_position[4]-final_position[4]]
-			my_vec=tuple(vec)
-			dend_add3d=transpose(my_vec, dend, descendants, dend_add3d)
+			translation_vec=tuple(vec)
+			dend_add3d=transpose(translation_vec, dend, descendants, dend_add3d)
 
 			dend_add3d[change_these[0]][0][6]=dend_add3d[dend][-1][0]
 			dend_add3d[change_these[1]][0][6]=dend_add3d[dend][-1][0]

--- a/extract_swc_morphology.py
+++ b/extract_swc_morphology.py
@@ -248,9 +248,9 @@ def descend(dendrite_list, all_terminal, path):
 			descendants[dend]=[]
 			for n in dendrite_list:
 				if dend in path[n]:
-					tmp_list=path[n][::-1]
+					reversed_path=path[n][::-1]
 					allow=False
-					for k in tmp_list:
+					for k in reversed_path:
 						if dend==k:
 							allow=True
 						if allow==True:

--- a/first_run.py
+++ b/first_run.py
@@ -243,22 +243,22 @@ for file_name in file_names:
 	average_apical_t_length.append(apical_t_length)
 
 	t_area=total_area(dendrite_list, area)
-	fdendlist=directory+'downloads/statistics/'+file_name+'_all_total_area.txt'
-	f = open(fdendlist, 'w+')
+	stats_file_path=directory+'downloads/statistics/'+file_name+'_all_total_area.txt'
+	f = open(stats_file_path, 'w+')
 	print(t_area, file=f)
 	f.close()
 	average_t_area.append(t_area)
-
+	
 	basal_t_area=total_area(basal, area)
-	fdendlist=directory+'downloads/statistics/'+file_name+'_basal_total_area.txt'
-	f = open(fdendlist, 'w+')
+	stats_file_path=directory+'downloads/statistics/'+file_name+'_basal_total_area.txt'
+	f = open(stats_file_path, 'w+')
 	print(basal_t_area, file=f)
 	f.close()
 	average_basal_t_area.append(basal_t_area)
-
+	
 	apical_t_area=total_area(apical, area)
-	fdendlist=directory+'downloads/statistics/'+file_name+'_apical_total_area.txt'
-	f = open(fdendlist, 'w+')
+	stats_file_path=directory+'downloads/statistics/'+file_name+'_apical_total_area.txt'
+	f = open(stats_file_path, 'w+')
 	print(apical_t_area, file=f)
 	f.close()
 	average_apical_t_area.append(apical_t_area)
@@ -286,20 +286,20 @@ for file_name in file_names:
 	f.close()
 	average_num_apical_bpoints.append(len(list(set([parental_points[x] for x in apical_bpoints if parental_points[x] not in soma]))))
 
-	fdendlist=directory+'downloads/statistics/'+file_name+'_list_of_all_dendrites.txt'
-	f = open(fdendlist, 'w+')
+	stats_file_path=directory+'downloads/statistics/'+file_name+'_list_of_all_dendrites.txt'
+	f = open(stats_file_path, 'w+')
 	for dend in dendrite_list:
 		print(dend, file=f)
 	f.close()
-
-	fdendlist=directory+'downloads/statistics/'+file_name+'_list_of_basal_dendrites.txt'
-	f = open(fdendlist, 'w+')
+	
+	stats_file_path=directory+'downloads/statistics/'+file_name+'_list_of_basal_dendrites.txt'
+	f = open(stats_file_path, 'w+')
 	for dend in basal:
 		print(dend, file=f)
 	f.close()
-
-	fdendlist=directory+'downloads/statistics/'+file_name+'_list_of_apical_dendrites.txt'
-	f = open(fdendlist, 'w+')
+	
+	stats_file_path=directory+'downloads/statistics/'+file_name+'_list_of_apical_dendrites.txt'
+	f = open(stats_file_path, 'w+')
 	for dend in apical:
 		print(dend, file=f)
 	f.close()
@@ -325,7 +325,7 @@ for file_name in file_names:
 	'''if basal_t_length<150 or apical_t_length<150:
 
 		import os
-		os.remove(fdendlist)
+                os.remove(stats_file_path)
 		os.remove(fdendlength)
 		os.remove(fnumdend)
 		os.remove(ftotlength)


### PR DESCRIPTION
## Summary
- clarify cross product variable in `createP`
- fix leftover references in `shrink` and `extend`
- rename path reversal variable for readability
- use `stats_file_path` for statistic outputs

## Testing
- `python3 -m py_compile $(git ls-files '*.py' | grep -v '^trash/')`