### PR TITLE
Fix string comparison for file filtering

### DIFF
--- a/first_run.py
+++ b/first_run.py
@@ -68,7 +68,7 @@ if (len(sys.argv)==3):
 
         directory=str(sys.argv[1])
         file_names=str(sys.argv[2]).split(',')
-        file_names=[x for x in file_names if x is not '']
+        file_names=[x for x in file_names if x != '']
 
         parsed_files=[]
 


### PR DESCRIPTION
## Summary
- correct the string comparison when filtering filenames

## Testing
- `python - <<'EOF'
file_names=['file1', '', 'file2', '', '', 'file3']
file_names=[x for x in file_names if x != '']
print(file_names)
EOF`