### PR TITLE
Replace star imports in first_run.py

### DIFF
--- a/first_run.py
+++ b/first_run.py
@@ -1,8 +1,17 @@
-from extract_swc_morphology import *
-from neuron_visualization import *
-from statistics_swc import *
-from random_sampling import *
-from actions_swc import *
+from extract_swc_morphology import read_file
+from neuron_visualization import first_graph
+from statistics_swc import (
+    total_length,
+    total_area,
+    bo_frequency,
+    bo_dlength,
+    bo_plength,
+    path_length,
+    sholl_length,
+    sholl_bp,
+    sholl_intersections,
+    branch_order,
+)
 from utils import round_to, write_json
 import sys
 import numpy as np


### PR DESCRIPTION
## Summary
- import only used names instead of using star imports in `first_run.py`

## Testing
- `python -m py_compile first_run.py`
