### PR TITLE
Use pathlib for path handling

### DIFF
--- a/actions_swc.py
+++ b/actions_swc.py
@@ -3,6 +3,7 @@ from random import randint
 import copy
 import sys
 import os
+from pathlib import Path
 
 import numpy as np
 from random import uniform, randrange
@@ -13,8 +14,8 @@ def length_distribution(): #parses the length distribution
 
         length=[]
         frequency=[]
-        current_directory=os.getcwd()
-        fname=current_directory+'/length_distribution.txt'
+        current_directory = Path.cwd()
+        fname = current_directory / 'length_distribution.txt'
         with open(fname) as f:
                 for line in f:
                         line=line.rstrip('\n')

--- a/first_run.py
+++ b/first_run.py
@@ -16,6 +16,7 @@ from utils import round_to, write_json
 import sys
 import numpy as np
 import os
+from pathlib import Path
 import time
 
 start_time = time.time()
@@ -75,14 +76,14 @@ def median_dict(d):
 
 if (len(sys.argv)==3):
 
-        directory=str(sys.argv[1])
+        directory = Path(sys.argv[1])
         file_names=str(sys.argv[2]).split(',')
         file_names=[x for x in file_names if x != '']
 
         parsed_files=[]
 
         parsed_count=0
-        log_file = os.path.join(directory, 'log_parsed_files.txt')
+        log_file = directory / 'log_parsed_files.txt'
         if os.path.isfile(log_file):
 
                 with open(log_file) as f:
@@ -99,15 +100,15 @@ else:
         print("The program failed.\nThe number of argument(s) given is " + str(len(sys.argv))+ ".\n3 arguments are needed: 1) first_run.py 2) directory path and 3) file name. ")
         sys.exit(0)
 
-exist_downloads=os.path.join(directory, 'downloads')
-exist_statistics=os.path.join(directory, 'downloads', 'statistics')
+exist_downloads = directory / 'downloads'
+exist_statistics = directory / 'downloads' / 'statistics'
 stats_dir = exist_statistics
 
-if not os.path.exists(exist_downloads):
-    os.makedirs(exist_downloads)
+if not exist_downloads.exists():
+    exist_downloads.mkdir(parents=True)
 
-if not os.path.exists(exist_statistics):
-    os.makedirs(exist_statistics)
+if not exist_statistics.exists():
+    exist_statistics.mkdir(parents=True)
 
 average_number_of_all_dendrites=[]
 average_number_of_all_terminal_dendrites=[]
@@ -171,14 +172,14 @@ if parsed_count>0:
         print('Retrieving previously calculated morphometric statistics')
         print()
 
-        fpickle=os.path.join(directory, 'current_average_statistics.p')
+        fpickle = directory / 'current_average_statistics.p'
         with open(fpickle, "rb") as f:
                 (average_number_of_all_terminal_dendrites,average_number_of_basal_terminal_dendrites,average_number_of_apical_terminal_dendrites,average_number_of_all_terminal_dendrites,average_number_of_basal_terminal_dendrites,average_number_of_apical_terminal_dendrites,average_t_length,average_basal_t_length,average_apical_t_length,average_t_area,average_basal_t_area,average_apical_t_area,average_num_all_bpoints,average_num_basal_bpoints,average_num_apical_bpoints,average_all_bo_frequency,average_basal_bo_frequency,average_apical_bo_frequency,average_all_bo_dlength,average_basal_bo_dlength,average_apical_bo_dlength,average_all_bo_plength,average_basal_bo_plength,average_apical_bo_plength,average_sholl_all_length,average_sholl_basal_length,average_sholl_apical_length,average_sholl_all_bp,average_sholl_basal_bp,average_sholl_apical_bp,average_sholl_all_intersections,average_sholl_apical_intersections,average_sholl_apical_intersections) = pickle.load(f)
 
 
 for file_name in file_names:
 
-        fname=os.path.join(directory, file_name)
+        fname = directory / file_name
 
         file_name=file_name.replace('.swc','')
 
@@ -510,12 +511,12 @@ for file_name in file_names:
 
         clearall()
 
-with open(os.path.join(directory, "log_parsed_files.txt"), "a+") as f:
+with open(directory / "log_parsed_files.txt", "a+") as f:
         for file_name in file_names:
                 print(file_name, file=f)
 
 import pickle, os
-fpickle=os.path.join(directory, 'current_average_statistics.p')
+fpickle = directory / 'current_average_statistics.p'
 with open(fpickle, "wb") as f:
         pickle.dump([average_number_of_all_terminal_dendrites,average_number_of_basal_terminal_dendrites,average_number_of_apical_terminal_dendrites,average_number_of_all_terminal_dendrites,average_number_of_basal_terminal_dendrites,average_number_of_apical_terminal_dendrites,average_t_length,average_basal_t_length,average_apical_t_length,average_t_area,average_basal_t_area,average_apical_t_area,average_num_all_bpoints,average_num_basal_bpoints,average_num_apical_bpoints,average_all_bo_frequency,average_basal_bo_frequency,average_apical_bo_frequency,average_all_bo_dlength,average_basal_bo_dlength,average_apical_bo_dlength,average_all_bo_plength,average_basal_bo_plength,average_apical_bo_plength,average_sholl_all_length,average_sholl_basal_length,average_sholl_apical_length,average_sholl_all_bp,average_sholl_basal_bp,average_sholl_apical_bp,average_sholl_all_intersections,average_sholl_apical_intersections,average_sholl_apical_intersections], f)
 

--- a/neuron_visualization.py
+++ b/neuron_visualization.py
@@ -2,6 +2,7 @@ import re
 from math import sqrt
 from random import randint
 import sys
+from pathlib import Path
 
 import numpy as np
 from random import uniform, randrange
@@ -53,8 +54,8 @@ def first_graph(abs_path, file_name, dendrite_list, dend_add3d, points, parental
 
                         my_plot.append([x, y, z, xp, yp, zp, d, dend, '0x0000FF'])
 
-        fname=file_name.replace('.swc','') + '_before.txt'
-        name=abs_path+fname
+        fname = file_name.replace('.swc','') + '_before.txt'
+        name = Path(abs_path) / fname
 
         with open(name, 'w') as f:
                 for i in my_plot:
@@ -108,8 +109,8 @@ def second_graph(abs_path,file_name, dendrite_list, dend_add3d, points, parental
         print('>>' + str(len(my_plot)))
 
         print(file_name)
-        fname=file_name.replace('.swc','') + '_after.txt'
-        name=abs_path+fname
+        fname = file_name.replace('.swc','') + '_after.txt'
+        name = Path(abs_path) / fname
 
         with open(name, 'w') as f:
                 for i in my_plot:

--- a/print_file.py
+++ b/print_file.py
@@ -1,8 +1,10 @@
 import os
+from pathlib import Path
 
 def print_newfile_tmp(directory, file_name, newfile, edit):
 
-        new_name=os.path.join(directory, file_name.replace('.swc','') + '_new_tmp.swc')
+        directory = Path(directory)
+        new_name = directory / (file_name.replace('.swc','') + '_new_tmp.swc')
 
         with open(new_name, 'w') as f:
                 print(('\n').join(newfile), file=f)
@@ -10,13 +12,12 @@ def print_newfile_tmp(directory, file_name, newfile, edit):
 
 def print_newfile(directory, file_name, newfile, edit):
 
-        directory=os.path.join(str(directory), 'downloads', 'files')
+        directory = Path(directory) / 'downloads' / 'files'
 
-        if not os.path.exists(directory):
-                os.makedirs(directory)
+        if not directory.exists():
+                directory.mkdir(parents=True)
 
-        new_name=os.path.join(directory, file_name)#.replace('.swc','') + '_new.swc'
-        new_name=os.path.join(directory, file_name.replace('.swc','') + '_new.swc')
+        new_name = directory / (file_name.replace('.swc','') + '_new.swc')
 
         with open(new_name, 'w') as f:
                 print(edit, file=f)

--- a/second_run.py
+++ b/second_run.py
@@ -9,6 +9,7 @@ from utils import round_to
 import sys
 import datetime
 import os
+from pathlib import Path
 import argparse
 
 #python second_run.py /home/bozelosp/Dropbox/remod/swc/ 0-2.swc who_all_terminal 0 none none percent 50 percent 50
@@ -36,9 +37,9 @@ def main():
     parser.add_argument("--diam-change", default="none", help="Extent of diameter change")
     args = parser.parse_args()
 
-    directory = args.directory
+    directory = Path(args.directory)
     file_name = args.file_name
-    fname = directory + file_name
+    fname = directory / file_name
 
     who = args.who
     if who in ['who_random_all', 'who_random_apical', 'who_random_basal']:
@@ -54,14 +55,14 @@ def main():
     var_choice = args.var_choice
     diam_change = args.diam_change
 
-    exist_downloads=str(directory)+'/downloads'
-    exist_downloads_files=str(directory)+'/downloads/files'
+    exist_downloads = directory / 'downloads'
+    exist_downloads_files = directory / 'downloads' / 'files'
     
-    if not os.path.exists(exist_downloads):
-        os.makedirs(exist_downloads)
+    if not exist_downloads.exists():
+        exist_downloads.mkdir(parents=True)
     
-    if not os.path.exists(exist_downloads_files):
-        os.makedirs(exist_downloads_files)
+    if not exist_downloads_files.exists():
+        exist_downloads_files.mkdir(parents=True)
     
     print()
     print('Open file: ' + str(file_name))
@@ -169,7 +170,7 @@ def main():
     check_indices(newfile) #check if indices are continuous from 0 and u
     print_newfile(directory, file_name, newfile, edit)
     
-    fname=directory+'downloads/files/'+file_name.replace('.swc','') + '_new.swc'
+    fname = directory / 'downloads' / 'files' / (file_name.replace('.swc','') + '_new.swc')
     (swc_lines, points, comment_lines, parents, branch_points, axon_bpoints, basal_bpoints, apical_bpoints, else_bpoints, soma_index, max_index, dendrite_list, descendants, dend_indices, dend_names, axon, basal, apical, elsep, dend_add3d, path, all_terminal, basal_terminal, apical_terminal, dist, area, branch_order, con, parental_points)=read_file(fname)
     second_graph(directory, file_name, dendrite_list, dend_add3d, points, parental_points, soma_index) #plots the original and modified tree (overlaying one another)
     

--- a/smart_merge.py
+++ b/smart_merge.py
@@ -1,5 +1,6 @@
 from plot_individual_data import *
 import os
+from pathlib import Path
 import re
 import sys
 import argparse
@@ -29,9 +30,9 @@ def main():
     parser.add_argument("--output-dir", required=True, dest="output_dir", help="Output directory for comparison files")
     args = parser.parse_args()
 
-    before_dir = args.before_dir
-    after_dir = args.after_dir
-    output_dir = args.output_dir
+    before_dir = Path(args.before_dir)
+    after_dir = Path(args.after_dir)
+    output_dir = Path(args.output_dir)
 
     before_files = read_files(before_dir)
     before_files = [x for x in before_files if re.search('average', x)]
@@ -46,10 +47,10 @@ def main():
 
     for f in to_merge_files:
 
-        f_before = os.path.join(before_dir, f)
+        f_before = before_dir / f
         lines_before = append_lines(f_before)
 
-        f_after = os.path.join(after_dir, f)
+        f_after = after_dir / f
         lines_after = append_lines(f_after)
 
         if len(lines_before) > len(lines_after):
@@ -62,7 +63,7 @@ def main():
             use_before_as_base = False
 
         f = f.replace('average', 'comparison/compare')
-        fw = output_dir + f
+        fw = output_dir / f
 
         with open(fw, 'w+') as f_write:
 
@@ -85,10 +86,11 @@ def main():
                         print(re.sub(r'\s(\S+)', r' 0', lines_after[i]), lines_after[i].rstrip('\n'), file=f_write)
 
 
-    if not os.path.exists(output_dir + 'comparison/'):
-        os.makedirs(output_dir + 'comparison/')
+    comparison_dir = output_dir / 'comparison'
+    if not comparison_dir.exists():
+        comparison_dir.mkdir(parents=True)
 
-    plot_compare_data(output_dir + 'comparison/')
+    plot_compare_data(comparison_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch to `Path` in helper modules and command-line tools
- adjust file writing utilities to use pathlib paths
- update existence checks and directory creation to pathlib methods

## Testing
- `python -m py_compile actions_swc.py neuron_visualization.py print_file.py second_run.py smart_merge.py first_run.py`