### PR TITLE
Replace bo with branch_order

### DIFF
--- a/first_run.py
+++ b/first_run.py
@@ -3,9 +3,9 @@ from neuron_visualization import first_graph
 from statistics_swc import (
     total_length,
     total_area,
-    bo_frequency,
-    bo_dlength,
-    bo_plength,
+    branch_order_frequency,
+    branch_order_dlength,
+    branch_order_plength,
     path_length,
     sholl_length,
     sholl_bp,
@@ -347,7 +347,7 @@ def main():
                     continue'''
     
             branch_order_values = branch_order_map
-            branch_order_freq, branch_order_max = bo_frequency(dendrite_list, branch_order_values)
+            branch_order_freq, branch_order_max = branch_order_frequency(dendrite_list, branch_order_values)
             results['number_of_all_dendrites_per_branch_order'] = branch_order_freq
             for order in branch_order_freq:
                     average_all_branch_order_frequency[order].append(branch_order_freq[order])
@@ -357,7 +357,7 @@ def main():
             if len(basal) > 0:
 
                     branch_order_basal = branch_order(basal, path)
-                    branch_order_freq, branch_order_max_basal = bo_frequency(basal, branch_order_values)
+                    branch_order_freq, branch_order_max_basal = branch_order_frequency(basal, branch_order_values)
                     results['number_of_basal_dendrites_per_branch_order'] = branch_order_freq
                     for order in branch_order_freq:
                             average_basal_branch_order_frequency[order].append(branch_order_freq[order])
@@ -367,44 +367,44 @@ def main():
             if len(apical) > 0:
 
                     branch_order_apical = branch_order(apical, path)
-                    branch_order_freq, branch_order_max_apical = bo_frequency(apical, branch_order_values)
+                    branch_order_freq, branch_order_max_apical = branch_order_frequency(apical, branch_order_values)
                     results['number_of_apical_dendrites_per_branch_order'] = branch_order_freq
                     for order in branch_order_freq:
                             average_apical_branch_order_frequency[order].append(branch_order_freq[order])
     
-            branch_order_dlen = bo_dlength(dendrite_list, branch_order_values, branch_order_max, dist)
+            branch_order_dlen = branch_order_dlength(dendrite_list, branch_order_values, branch_order_max, dist)
             results['all_dendritic_length_per_branch_order'] = branch_order_dlen
             for order in branch_order_dlen:
                     average_all_branch_order_dlength[order].append(branch_order_dlen[order])
     
             if branch_order_basal is not None:
-                    branch_order_dlen = bo_dlength(basal, branch_order_basal, branch_order_max_basal, dist)
+                    branch_order_dlen = branch_order_dlength(basal, branch_order_basal, branch_order_max_basal, dist)
                     results['basal_dendritic_length_per_branch_order'] = branch_order_dlen
                     for order in branch_order_dlen:
                             average_basal_branch_order_dlength[order].append(branch_order_dlen[order])
     
             if branch_order_apical is not None:
-                    branch_order_dlen = bo_dlength(apical, branch_order_apical, branch_order_max_apical, dist)
+                    branch_order_dlen = branch_order_dlength(apical, branch_order_apical, branch_order_max_apical, dist)
                     results['apical_dendritic_length_per_branch_order'] = branch_order_dlen
                     for order in branch_order_dlen:
                             average_apical_branch_order_dlength[order].append(branch_order_dlen[order])
     
             plength=path_length(dendrite_list, path, dist)
-            branch_order_plen=bo_plength(dendrite_list, branch_order_values, branch_order_max, plength)
+            branch_order_plen=branch_order_plength(dendrite_list, branch_order_values, branch_order_max, plength)
             results['all_path_length_per_branch_order'] = branch_order_plen
             for order in branch_order_plen:
                     average_all_branch_order_plength[order].append(branch_order_plen[order])
     
             if branch_order_basal is not None:
                     plength=path_length(basal, path, dist)
-                    branch_order_plen=bo_plength(basal, branch_order_basal, branch_order_max_basal, plength)
+                    branch_order_plen=branch_order_plength(basal, branch_order_basal, branch_order_max_basal, plength)
                     results['basal_path_length_per_branch_order'] = branch_order_plen
                     for order in branch_order_plen:
                             average_basal_branch_order_plength[order].append(branch_order_plen[order])
     
             if branch_order_apical is not None:
                     plength=path_length(apical, path, dist)
-                    branch_order_plen=bo_plength(apical, branch_order_apical, branch_order_max_apical, plength)
+                    branch_order_plen=branch_order_plength(apical, branch_order_apical, branch_order_max_apical, plength)
                     results['apical_path_length_per_branch_order'] = branch_order_plen
                     for order in branch_order_plen:
                             average_apical_branch_order_plength[order].append(branch_order_plen[order])
@@ -701,8 +701,8 @@ def main():
     print()
     print("Average Number of All Dendrites per Branch Order: ") 
     average_dict(average_all_branch_order_frequency)
-    f_average_bo_frequency=os.path.join(stats_dir, 'average_number_of_all_dendrites_per_branch_order.txt')
-    with open(f_average_bo_frequency, 'w+') as f:
+    f_average_branch_order_frequency=os.path.join(stats_dir, 'average_number_of_all_dendrites_per_branch_order.txt')
+    with open(f_average_branch_order_frequency, 'w+') as f:
             for i in average_all_branch_order_frequency:
                     print(i,  ' '.join(map(str, average_all_branch_order_frequency[i])))
                     print(i, ' '.join(map(str, average_all_branch_order_frequency[i])), file=f)
@@ -710,8 +710,8 @@ def main():
     print()
     print("Average Number of Basal Dendrites per Branch Order: ")
     average_dict(average_basal_branch_order_frequency)
-    f_average_bo_frequency=os.path.join(stats_dir, 'average_number_of_basal_dendrites_per_branch_order.txt')
-    with open(f_average_bo_frequency, 'w+') as f:
+    f_average_branch_order_frequency=os.path.join(stats_dir, 'average_number_of_basal_dendrites_per_branch_order.txt')
+    with open(f_average_branch_order_frequency, 'w+') as f:
             for i in average_basal_branch_order_frequency:
                     print(i,  ' '.join(map(str, average_basal_branch_order_frequency[i])))
                     print(i, ' '.join(map(str, average_basal_branch_order_frequency[i])), file=f)
@@ -719,8 +719,8 @@ def main():
     print()
     print("Average Number of Apical Dendrites per Branch Order: ")
     average_dict(average_apical_branch_order_frequency)
-    f_average_bo_frequency=os.path.join(stats_dir, 'average_number_of_apical_dendrites_per_branch_order.txt')
-    with open(f_average_bo_frequency, 'w+') as f:
+    f_average_branch_order_frequency=os.path.join(stats_dir, 'average_number_of_apical_dendrites_per_branch_order.txt')
+    with open(f_average_branch_order_frequency, 'w+') as f:
             for i in average_apical_branch_order_frequency:
                     print(i,  ' '.join(map(str, average_apical_branch_order_frequency[i])))
                     print(i, ' '.join(map(str, average_apical_branch_order_frequency[i])), file=f)
@@ -728,8 +728,8 @@ def main():
     print()
     print("Average All Dendritic Length per Branch Order: ")
     average_dict(average_all_branch_order_dlength)
-    f_average_bo_dlength=os.path.join(stats_dir, 'average_all_dendritic_length_per_branch_order.txt')
-    with open(f_average_bo_dlength, 'w+') as f:
+    f_average_branch_order_dlength=os.path.join(stats_dir, 'average_all_dendritic_length_per_branch_order.txt')
+    with open(f_average_branch_order_dlength, 'w+') as f:
             for i in average_all_branch_order_dlength:
                     print(i, ' '.join(map(str, average_all_branch_order_dlength[i])))
                     print(i, ' '.join(map(str, average_all_branch_order_dlength[i])), file=f)
@@ -737,8 +737,8 @@ def main():
     print()
     print("Average Basal Dendritic Length per Branch Order: ")
     average_dict(average_basal_branch_order_dlength)
-    f_average_bo_dlength=os.path.join(stats_dir, 'average_basal_dendritic_length_per_branch_order.txt')
-    with open(f_average_bo_dlength, 'w+') as f:
+    f_average_branch_order_dlength=os.path.join(stats_dir, 'average_basal_dendritic_length_per_branch_order.txt')
+    with open(f_average_branch_order_dlength, 'w+') as f:
             for i in average_basal_branch_order_dlength:
                     print(i, ' '.join(map(str, average_basal_branch_order_dlength[i])))
                     print(i, ' '.join(map(str, average_basal_branch_order_dlength[i])), file=f)
@@ -746,8 +746,8 @@ def main():
     print()
     print("Average Apical Dendritic Length per Branch Order: ")
     average_dict(average_apical_branch_order_dlength)
-    f_average_bo_dlength=os.path.join(stats_dir, 'average_apical_dendritic_length_per_branch_order.txt')
-    with open(f_average_bo_dlength, 'w+') as f:
+    f_average_branch_order_dlength=os.path.join(stats_dir, 'average_apical_dendritic_length_per_branch_order.txt')
+    with open(f_average_branch_order_dlength, 'w+') as f:
             for i in average_apical_branch_order_dlength:
                     print(i, ' '.join(map(str, average_apical_branch_order_dlength[i])))
                     print(i, ' '.join(map(str, average_apical_branch_order_dlength[i])), file=f)
@@ -755,8 +755,8 @@ def main():
     print()
     print("Average All Path Length per Branch Order: ")
     average_dict(average_all_branch_order_plength)
-    f_average_bo_plength=os.path.join(stats_dir, 'average_all_path_length_per_branch_order.txt')
-    with open(f_average_bo_plength, 'w+') as f:
+    f_average_branch_order_plength=os.path.join(stats_dir, 'average_all_path_length_per_branch_order.txt')
+    with open(f_average_branch_order_plength, 'w+') as f:
             for i in average_all_branch_order_plength:
                     print(i, ' '.join(map(str, average_all_branch_order_plength[i])))
                     print(i, ' '.join(map(str, average_all_branch_order_plength[i])), file=f)
@@ -764,8 +764,8 @@ def main():
     print()
     print("Average Basal Path Length per Branch Order: ")
     average_dict(average_basal_branch_order_plength)
-    f_average_bo_plength=os.path.join(stats_dir, 'average_basal_path_length_per_branch_order.txt')
-    with open(f_average_bo_plength, 'w+') as f:
+    f_average_branch_order_plength=os.path.join(stats_dir, 'average_basal_path_length_per_branch_order.txt')
+    with open(f_average_branch_order_plength, 'w+') as f:
             for i in average_basal_branch_order_plength:
                     print(i, ' '.join(map(str, average_basal_branch_order_plength[i])))
                     print(i, ' '.join(map(str, average_basal_branch_order_plength[i])), file=f)
@@ -773,8 +773,8 @@ def main():
     print()
     print("Average Apical Path Length per Branch Order: ")
     average_dict(average_apical_branch_order_plength)
-    f_average_bo_plength=os.path.join(stats_dir, 'average_apical_path_length_per_branch_order.txt')
-    with open(f_average_bo_plength, 'w+') as f:
+    f_average_branch_order_plength=os.path.join(stats_dir, 'average_apical_path_length_per_branch_order.txt')
+    with open(f_average_branch_order_plength, 'w+') as f:
             for i in average_apical_branch_order_plength:
                     print(i, ' '.join(map(str, average_apical_branch_order_plength[i])))
                     print(i, ' '.join(map(str, average_apical_branch_order_plength[i])), file=f)

--- a/index_reassignment.py
+++ b/index_reassignment.py
@@ -1,34 +1,34 @@
 from statistics_swc import *
 
-def index_reassign(dendrite_list, dend_add3d, branch_order_map, con, axon, basal, apical, elsep, soma_index, bo_max, action):
+def index_reassign(dendrite_list, dend_add3d, branch_order_map, con, axon, basal, apical, elsep, soma_index, branch_order_max, action):
 
 
         if action == 'branch':
-                bo_max+=1
+                branch_order_max+=1
 
-        bo_sorted_axon_dends=[]
-        for i in range(1,bo_max+1):
+        branch_order_sorted_axon_dends=[]
+        for i in range(1,branch_order_max+1):
                 for dend in axon:
                         if branch_order_map[dend]==i:
-                                bo_sorted_axon_dends.append(dend)
+                                branch_order_sorted_axon_dends.append(dend)
 
-        bo_sorted_basal_dends=[]
-        for i in range(1,bo_max+1):
+        branch_order_sorted_basal_dends=[]
+        for i in range(1,branch_order_max+1):
                 for dend in basal:
                         if branch_order_map[dend]==i:
-                                bo_sorted_basal_dends.append(dend)
+                                branch_order_sorted_basal_dends.append(dend)
 
-        bo_sorted_apical_dends=[]
-        for i in range(1,bo_max+1):
+        branch_order_sorted_apical_dends=[]
+        for i in range(1,branch_order_max+1):
                 for dend in apical:
                         if branch_order_map[dend]==i:
-                                bo_sorted_apical_dends.append(dend)
+                                branch_order_sorted_apical_dends.append(dend)
 
-        bo_sorted_elsep_dends=[]
-        for i in range(1,bo_max+1):
+        branch_order_sorted_elsep_dends=[]
+        for i in range(1,branch_order_max+1):
                 for dend in elsep:
                         if branch_order_map[dend]==i:
-                                bo_sorted_elsep_dends.append(dend)
+                                branch_order_sorted_elsep_dends.append(dend)
 
         segment_list=[]
 
@@ -58,7 +58,7 @@ def index_reassign(dendrite_list, dend_add3d, branch_order_map, con, axon, basal
                         index+=1
                         segment_list.append(soma_index[i])
 
-        for dend in bo_sorted_axon_dends:
+        for dend in branch_order_sorted_axon_dends:
 
                 for i in range(len(dend_add3d[dend])):
 
@@ -100,7 +100,7 @@ def index_reassign(dendrite_list, dend_add3d, branch_order_map, con, axon, basal
                                         index+=1
                                         segment_list.append(dend_add3d[dend][i])
 
-        for dend in bo_sorted_basal_dends:
+        for dend in branch_order_sorted_basal_dends:
 
                 for i in range(len(dend_add3d[dend])):
 
@@ -142,7 +142,7 @@ def index_reassign(dendrite_list, dend_add3d, branch_order_map, con, axon, basal
                                         index+=1
                                         segment_list.append(dend_add3d[dend][i])
 
-        for dend in bo_sorted_apical_dends:
+        for dend in branch_order_sorted_apical_dends:
 
                 for i in range(len(dend_add3d[dend])):
 
@@ -184,7 +184,7 @@ def index_reassign(dendrite_list, dend_add3d, branch_order_map, con, axon, basal
                                         index+=1
                                         segment_list.append(dend_add3d[dend][i])
 
-        for dend in bo_sorted_elsep_dends:
+        for dend in branch_order_sorted_elsep_dends:
 
                 for i in range(len(dend_add3d[dend])):
 

--- a/second_run.py
+++ b/second_run.py
@@ -122,7 +122,7 @@ def main():
     print('The dendrites stemming from these segments will be edited: ')
     print(str(who))
     
-    (bo_freq, bo_max)=bo_frequency(dendrite_list, branch_order)
+    (branch_order_freq, branch_order_max)=branch_order_frequency(dendrite_list, branch_order)
     
     if action == 'shrink':
         if hm_choice == 'micrometers':
@@ -142,7 +142,7 @@ def main():
     (newfile, dendrite_list, segment_list)=execute_action(who, action, amount, hm_choice, dend_add3d, dist, max_index, diam_change, dendrite_list, soma_index, points, parental_points, descendants, all_terminal) #executes the selected action and print the modified tree to a '*_new.hoc' file
     
     if action in ['shrink', 'remove', 'scale']:
-        newfile=index_reassign(dendrite_list, dend_add3d, branch_order, con, axon, basal, apical, elsep, soma_index, bo_max, action)
+        newfile=index_reassign(dendrite_list, dend_add3d, branch_order, con, axon, basal, apical, elsep, soma_index, branch_order_max, action)
     
     newfile=comment_lines + newfile
     check_indices(newfile) #check if indices are continuous from 0 and u

--- a/statistics_swc.py
+++ b/statistics_swc.py
@@ -35,20 +35,20 @@ def median_diameter(dendrite_list, dend_add3d):
 def print_branch_order(dendrite_list, branch_order):
         """Return a sorted list of (dendrite, branch_order) tuples."""
 
-        bo_dict = {d: branch_order[d] for d in dendrite_list}
-        return sorted(bo_dict.items(), key=lambda x: x[0])
+        branch_order_dict = {d: branch_order[d] for d in dendrite_list}
+        return sorted(branch_order_dict.items(), key=lambda x: x[0])
 
-def bo_frequency(dendrite_list, branch_order):
+def branch_order_frequency(dendrite_list, branch_order):
         """Return the frequency of each branch order."""
 
         orders = [branch_order[d] for d in dendrite_list]
         counter = Counter(orders)
-        bo_max = max(counter) if counter else 0
-        bo_freq = {i: counter.get(i, 0) for i in range(1, bo_max + 1)}
+        branch_order_max = max(counter) if counter else 0
+        branch_order_freq = {i: counter.get(i, 0) for i in range(1, branch_order_max + 1)}
 
-        return bo_freq, bo_max
+        return branch_order_freq, branch_order_max
 
-def bo_dlength(dendrite_list, branch_order, bo_max, dist):
+def branch_order_dlength(dendrite_list, branch_order, branch_order_max, dist):
         """Return average dendrite length per branch order."""
 
         acc = defaultdict(list)
@@ -57,7 +57,7 @@ def bo_dlength(dendrite_list, branch_order, bo_max, dist):
 
         return {k: sum(v)/len(v) for k, v in acc.items() if v}
 
-def bo_plength(dendrite_list, branch_order, bo_max, plength):
+def branch_order_plength(dendrite_list, branch_order, branch_order_max, plength):
         """Return average path length per branch order."""
 
         acc = defaultdict(list)

--- a/trash/sholl_analysis.py
+++ b/trash/sholl_analysis.py
@@ -1,7 +1,7 @@
-(swc_lines, points, comment_lines, parents, bpoints, soma_index, max_index, dlist, dend_points, dend_names, exceptions, basal, apical, dend_add3d, path, all_terminal, basal_terminal, apical_terminal, dist, bo, con, point_lines, ppoints)=read_file(fname) #extracts important connectivity and morphological data
+(swc_lines, points, comment_lines, parents, bpoints, soma_index, max_index, dlist, dend_points, dend_names, exceptions, basal, apical, dend_add3d, path, all_terminal, basal_terminal, apical_terminal, dist, branch_order, con, point_lines, ppoints)=read_file(fname) #extracts important connectivity and morphological data
 
-def sholl(dlist, dend_add3d, bo, con, point_lines, soma_index):
-	for i in soma_index:
-		print i
+def sholl(dlist, dend_add3d, branch_order, con, point_lines, soma_index):
+        for i in soma_index:
+                print(i)
 
-sholl(dlist, dend_add3d, bo, con, point_lines, soma_index)
+sholl(dlist, dend_add3d, branch_order, con, point_lines, soma_index)


### PR DESCRIPTION
## Summary
- rename bo helper functions to branch_order_*
- update imports and calls to use new branch_order_* names
- rename related variables such as branch_order_max and branch_order_sorted_* collections
- keep the repository compiling after changes

## Testing
- `python -m py_compile statistics_swc.py first_run.py second_run.py index_reassignment.py trash/sholl_analysis.py`