### PR TITLE
Refactor neuron visualization utilities

### DIFF
--- a/neuron_visualization.py
+++ b/neuron_visualization.py
@@ -1,7 +1,10 @@
 """Utility functions to export neuron morphology for visualisation."""
 
+from __future__ import annotations
+
+from itertools import chain
 from pathlib import Path
-from typing import Dict, Iterable, List, Sequence
+from typing import Dict, Iterable, Iterator, List, Sequence
 
 
 Color = str
@@ -10,24 +13,30 @@ DEFAULT_COLOR: Color = "0x0000FF"
 
 def _write_lines(path: Path, lines: Iterable[Sequence]) -> None:
     """Write formatted ``lines`` to ``path`` as space separated values."""
+
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
+    with path.open("w", encoding="utf-8") as f:
         for line in lines:
-            f.write(" ".join(str(x) for x in line) + "\n")
+            print(*line, file=f)
 
 
-def _soma_connections(soma_points: Sequence[Sequence]) -> List[List]:
-    """Return line segments connecting soma points to their parent."""
+def _soma_connections(soma_points: Sequence[Sequence]) -> Iterator[List]:
+    """Yield line segments connecting soma points to their parent."""
 
     lookup = {p[0]: p for p in soma_points}
-    segments: List[List] = []
     for p in soma_points:
         parent = lookup.get(p[6])
         if parent:
-            segments.append(
-                [p[2], p[3], p[4], parent[2], parent[3], parent[4], p[5], DEFAULT_COLOR]
-            )
-    return segments
+            yield [
+                p[2],
+                p[3],
+                p[4],
+                parent[2],
+                parent[3],
+                parent[4],
+                p[5],
+                DEFAULT_COLOR,
+            ]
 
 
 def _dendrite_connections(
@@ -38,17 +47,22 @@ def _dendrite_connections(
 ) -> List[List]:
     """Return line segments between dendrite points and their parents."""
 
-    segments: List[List] = []
     for dend in dendrite_list:
         for point in dend_add3d[dend]:
-            parent_idx = parental_points.get(point[6])
+            parent_idx = parental_points.get(point[6], -1)
             if parent_idx == -1 or point[1] == 2:
                 continue
             parent = points[parent_idx]
-            segments.append(
-                [point[2], point[3], point[4], parent[2], parent[3], parent[4], point[5], DEFAULT_COLOR]
-            )
-    return segments
+            yield [
+                point[2],
+                point[3],
+                point[4],
+                parent[2],
+                parent[3],
+                parent[4],
+                point[5],
+                DEFAULT_COLOR,
+            ]
 
 
 def _collect_segments(
@@ -60,11 +74,39 @@ def _collect_segments(
 ) -> List[List]:
     """Gather all line segments for soma and dendrites."""
 
-    segments = _soma_connections(soma_index)
-    segments.extend(
-        _dendrite_connections(dendrite_list, dend_add3d, points, parental_points)
+    return list(
+        chain(
+            _soma_connections(soma_index),
+            _dendrite_connections(
+                dendrite_list, dend_add3d, points, parental_points
+            ),
+        )
     )
-    return segments
+
+
+def _export_graph(
+    abs_path: Path | str,
+    file_name: str,
+    dendrite_list: Iterable[int],
+    dend_add3d: Dict[int, Sequence[Sequence]],
+    points: Dict[int, Sequence],
+    parental_points: Dict[int, int],
+    soma_index: Sequence[Sequence],
+    suffix: str,
+    verbose: bool = False,
+) -> None:
+    """Export coordinates for a morphology to ``*_suffix.txt``."""
+
+    segments = _collect_segments(
+        dendrite_list, dend_add3d, points, parental_points, soma_index
+    )
+
+    if verbose:
+        print(f">>{len(segments)}")
+        print(file_name)
+
+    out_path = Path(abs_path) / f"{file_name.replace('.swc', '')}_{suffix}.txt"
+    _write_lines(out_path, segments)
 
 
 def first_graph(
@@ -78,12 +120,16 @@ def first_graph(
 ) -> None:
     """Write coordinates of the original morphology to ``*_before.txt``."""
 
-    segments = _collect_segments(
-        dendrite_list, dend_add3d, points, parental_points, soma_index
+    _export_graph(
+        abs_path,
+        file_name,
+        dendrite_list,
+        dend_add3d,
+        points,
+        parental_points,
+        soma_index,
+        "before",
     )
-
-    out_path = Path(abs_path) / f"{file_name.replace('.swc', '')}_before.txt"
-    _write_lines(out_path, segments)
 
 def second_graph(
     abs_path: Path | str,
@@ -96,12 +142,16 @@ def second_graph(
 ) -> None:
     """Write coordinates of the edited morphology to ``*_after.txt``."""
 
-    segments = _collect_segments(
-        dendrite_list, dend_add3d, points, parental_points, soma_index
+    _export_graph(
+        abs_path,
+        file_name,
+        dendrite_list,
+        dend_add3d,
+        points,
+        parental_points,
+        soma_index,
+        "after",
+        verbose=True,
     )
 
-    print(f">>{len(segments)}")
-    print(file_name)
-
-    out_path = Path(abs_path) / f"{file_name.replace('.swc', '')}_after.txt"
-    _write_lines(out_path, segments)
+__all__ = ["first_graph", "second_graph"]


### PR DESCRIPTION
## Summary
- refactor neuron_visualization utilities
- factor out common graph export logic
- streamline generator usage for dendrite and soma segments

## Testing
- `python -m py_compile neuron_visualization.py`
- `find . -name '*.py' -not -path './trash/*' -print | xargs python -m py_compile`