### PR TITLE
Remove obsolete runner scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ to dendritic trees and visualise the results.
 - Parse SWC files and extract measurements such as branch counts, branch-order
   distributions, total length/area and Sholl profiles.
 - Automatically store aggregated statistics in `downloads/statistics/`.
-- Modify morphologies using `second_run.py` (remove, extend or change the
-  diameter of dendrites).
+- Modify morphologies using the unified `run.py edit` command to remove,
+  extend or change dendrites.
 - Visualise original and edited trees with 3‑D plots.
 - Additional helper scripts to merge segments and plot data. Node indices are
-  renumbered automatically by `second_run.py` after relevant edits.
+  renumbered automatically after relevant edits.
 
 ## Installation
 
@@ -34,30 +34,30 @@ Using a virtual environment is recommended but not mandatory.
 1. **Prepare your SWC files** – place your `.swc` files in a directory. Example
    data can be found under `trash/`.
 
-2. **Compute statistics** – run `first_run.py` and provide the directory and a
-   comma-separated list of file names:
+2. **Compute statistics** – run `run.py analyze` and provide
+   the directory and a comma-separated list of file names:
 
    ```bash
-   python first_run.py /path/to/swc 0-2.swc
+   python run.py analyze /path/to/swc 0-2.swc
    ```
 
    Results such as total dendritic length, branch-order frequency and Sholl
    intersections are saved in `downloads/statistics/`.
 
-3. **Remodel a morphology** – use `second_run.py` to apply structural changes.
+3. **Remodel a morphology** – use `run.py edit` to apply structural changes.
    The example below removes 50% of all terminal dendrites from `0-2.swc` and
    writes the modified neuron to `downloads/files/0-2_new.swc`:
 
    ```bash
-   python second_run.py \
-       --directory /path/to/swc \
-       --file-name 0-2.swc \
-       --who who_all_terminal \
-       --action remove \
-       --hm-choice percent \
-       --amount 50 \
-       --var-choice percent \
-       --diam-change 10
+   python run.py edit \
+      --directory /path/to/swc \
+      --file-name 0-2.swc \
+      --who who_all_terminal \
+      --action remove \
+      --hm-choice percent \
+      --amount 50 \
+      --var-choice percent \
+      --diam-change 10
    ```
 
 4. **Visualise** – run `neuron_visualization.py` or `graph.py` to generate 3‑D
@@ -68,13 +68,13 @@ Using a virtual environment is recommended but not mandatory.
 
 The individual scripts are designed to be used as a pipeline:
 
-1. **Analyse** – start with `first_run.py` to compute baseline statistics for a
+1. **Analyse** – start with `run.py analyze` to compute baseline statistics for a
    set of SWC files. It expects a directory and a comma-separated list of
    filenames. The resulting metrics are written to
    `downloads/statistics/`.
-2. **Modify** – apply structural changes with `second_run.py`. This script can remove, extend or shrink
-   selected dendrites and stores edited files under `downloads/files/`.
-3. **Reassign indices** – `second_run.py` automatically renumbers nodes after
+2. **Modify** – apply structural changes with `run.py edit`.
+   This script can remove, extend or shrink selected dendrites and stores edited files under `downloads/files/`.
+3. **Reassign indices** – `run.py edit` automatically renumbers nodes after
    modifications, so no extra command is needed.
 4. **Visualise and plot** – generate 3‑D views using `neuron_visualization.py`
    or `graph.py` and create summary plots with `plot_data.py` or

--- a/analysis.py
+++ b/analysis.py
@@ -65,14 +65,16 @@ def median_dict(d):
 
         return d
 
+
 # example usage: python first_run.py /path/to/swc/ 0-2.swc
-def main():
+def main(argv=None):
 
     start_time = time.time()
-    if (len(sys.argv)==3):
-    
-            directory = Path(sys.argv[1])
-            file_names=str(sys.argv[2]).split(',')
+    if argv is None:
+            argv = sys.argv[1:]
+    if len(argv)==2:
+            directory = Path(argv[0])
+            file_names=str(argv[1]).split(',')
             file_names=[x for x in file_names if x != '']
     
             parsed_files=[]
@@ -92,7 +94,7 @@ def main():
                     parsed_count=len(parsed_files)
     
     else:
-            print("The program failed.\nThe number of argument(s) given is " + str(len(sys.argv))+ ".\n3 arguments are needed: 1) first_run.py 2) directory path and 3) file name. ")
+            print("The program failed.\nThe number of argument(s) given is " + str(len(argv)) + ".\n2 arguments are needed: directory path and file name.")
             sys.exit(0)
     
     exist_downloads = directory / 'downloads'

--- a/editor.py
+++ b/editor.py
@@ -24,7 +24,7 @@ import argparse
 #python second_run.py /Users/bozelosp/Desktop/spruston01/ DH052814X100.swc who_manual none 780,1096,1205,1499,1775,1948,2069,2169 shrink percent 80 none none
 #python second_run.py /Users/bozelosp/Desktop/spruston01/ DH052814X100.swc who_manual none 780,1096,1205,1499,1775,1948,2069,2169 remove none none none none
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(description="Apply remodeling actions to SWC data")
     parser.add_argument("--directory", required=True, help="Base directory for the SWC file")
     parser.add_argument("--file-name", required=True, help="SWC filename")
@@ -39,7 +39,7 @@ def main():
     parser.add_argument("--var-choice", required=True, help="percent or micrometers for diameter change")
     parser.add_argument("--diam-change", type=float, default=None,
                         help="Extent of diameter change")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     directory = Path(args.directory)
     file_name = args.file_name

--- a/run.py
+++ b/run.py
@@ -1,0 +1,61 @@
+import argparse
+import sys
+
+import analysis
+import editor
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Compute statistics or remodel SWC files"
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    analyze = sub.add_parser("analyze", help="Compute morphometric statistics")
+    analyze.add_argument("directory", help="Directory containing SWC files")
+    analyze.add_argument("files", help="Comma separated list of file names")
+
+    edit = sub.add_parser("edit", help="Remodel a morphology")
+    edit.add_argument("--directory", required=True, help="Base directory for the SWC file")
+    edit.add_argument("--file-name", required=True, help="SWC filename")
+    edit.add_argument("--who", required=True, help="Target dendrite selection")
+    edit.add_argument("--random-ratio", type=float, default=0.0,
+                      help="Ratio for random selection (percent)")
+    edit.add_argument("--who-manual-variable", default="none",
+                      help="Comma separated manual dendrite ids")
+    edit.add_argument("--action", required=True, help="Remodeling action")
+    edit.add_argument("--hm-choice", required=True,
+                      help="percent or micrometers for extent")
+    edit.add_argument("--amount", type=float, default=None,
+                      help="Extent of the action")
+    edit.add_argument("--var-choice", required=True,
+                      help="percent or micrometers for diameter change")
+    edit.add_argument("--diam-change", type=float, default=None,
+                      help="Extent of diameter change")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "analyze":
+        analysis.main([args.directory, args.files])
+    elif args.command == "edit":
+        arglist = [
+            "--directory", args.directory,
+            "--file-name", args.file_name,
+            "--who", args.who,
+            "--random-ratio", str(args.random_ratio),
+            "--who-manual-variable", args.who_manual_variable,
+            "--action", args.action,
+            "--hm-choice", args.hm_choice,
+            "--var-choice", args.var_choice,
+        ]
+        if args.amount is not None:
+            arglist.extend(["--amount", str(args.amount)])
+        if args.diam_change is not None:
+            arglist.extend(["--diam-change", str(args.diam_change)])
+        editor.main(arglist)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rename `first_run.py` to `analysis.py`
- rename `second_run.py` to `editor.py`
- update `run.py` imports
- purge mentions of old filenames from the README

## Testing
- `python -m py_compile run.py analysis.py editor.py`