### PR TITLE
Rename confusing variable names

### DIFF
--- a/run.py
+++ b/run.py
@@ -193,11 +193,11 @@ def analyze_main(argv=None):
                     axon_bpoints,
                     basal_bpoints,
                     apical_bpoints,
-                    else_bpoints,
+                    soma_bpoints,
                     soma_index,
                     max_index,
                     dendrite_list,
-                    descendants,
+                    subtrees,
                     dend_indices,
                     dend_names,
                     axon,
@@ -335,42 +335,42 @@ def analyze_main(argv=None):
                         for order in branch_order_freq:
                                 average_apical_branch_order_frequency[order].append(branch_order_freq[order])
         
-                branch_order_dlen = branch_order_dlength(dendrite_list, branch_order_values, branch_order_max, dist)
-                results['all_dendritic_length_per_branch_order'] = branch_order_dlen
-                for order in branch_order_dlen:
-                        average_all_branch_order_dlength[order].append(branch_order_dlen[order])
+                branch_order_dlengths = branch_order_dlength(dendrite_list, branch_order_values, branch_order_max, dist)
+                results['all_dendritic_length_per_branch_order'] = branch_order_dlengths
+                for order in branch_order_dlengths:
+                        average_all_branch_order_dlength[order].append(branch_order_dlengths[order])
         
                 if branch_order_basal is not None:
-                        branch_order_dlen = branch_order_dlength(basal, branch_order_basal, branch_order_max_basal, dist)
-                        results['basal_dendritic_length_per_branch_order'] = branch_order_dlen
-                        for order in branch_order_dlen:
-                                average_basal_branch_order_dlength[order].append(branch_order_dlen[order])
+                        branch_order_dlengths = branch_order_dlength(basal, branch_order_basal, branch_order_max_basal, dist)
+                        results['basal_dendritic_length_per_branch_order'] = branch_order_dlengths
+                        for order in branch_order_dlengths:
+                                average_basal_branch_order_dlength[order].append(branch_order_dlengths[order])
         
                 if branch_order_apical is not None:
-                        branch_order_dlen = branch_order_dlength(apical, branch_order_apical, branch_order_max_apical, dist)
-                        results['apical_dendritic_length_per_branch_order'] = branch_order_dlen
-                        for order in branch_order_dlen:
-                                average_apical_branch_order_dlength[order].append(branch_order_dlen[order])
+                        branch_order_dlengths = branch_order_dlength(apical, branch_order_apical, branch_order_max_apical, dist)
+                        results['apical_dendritic_length_per_branch_order'] = branch_order_dlengths
+                        for order in branch_order_dlengths:
+                                average_apical_branch_order_dlength[order].append(branch_order_dlengths[order])
         
-                plength=path_length(dendrite_list, path, dist)
-                branch_order_plen=branch_order_plength(dendrite_list, branch_order_values, branch_order_max, plength)
-                results['all_path_length_per_branch_order'] = branch_order_plen
-                for order in branch_order_plen:
-                        average_all_branch_order_plength[order].append(branch_order_plen[order])
+                path_lengths=path_length(dendrite_list, path, dist)
+                branch_order_plengths=branch_order_plength(dendrite_list, branch_order_values, branch_order_max, path_lengths)
+                results['all_path_length_per_branch_order'] = branch_order_plengths
+                for order in branch_order_plengths:
+                        average_all_branch_order_plength[order].append(branch_order_plengths[order])
         
                 if branch_order_basal is not None:
-                        plength=path_length(basal, path, dist)
-                        branch_order_plen=branch_order_plength(basal, branch_order_basal, branch_order_max_basal, plength)
-                        results['basal_path_length_per_branch_order'] = branch_order_plen
-                        for order in branch_order_plen:
-                                average_basal_branch_order_plength[order].append(branch_order_plen[order])
+                        path_lengths=path_length(basal, path, dist)
+                        branch_order_plengths=branch_order_plength(basal, branch_order_basal, branch_order_max_basal, path_lengths)
+                        results['basal_path_length_per_branch_order'] = branch_order_plengths
+                        for order in branch_order_plengths:
+                                average_basal_branch_order_plength[order].append(branch_order_plengths[order])
         
                 if branch_order_apical is not None:
-                        plength=path_length(apical, path, dist)
-                        branch_order_plen=branch_order_plength(apical, branch_order_apical, branch_order_max_apical, plength)
-                        results['apical_path_length_per_branch_order'] = branch_order_plen
-                        for order in branch_order_plen:
-                                average_apical_branch_order_plength[order].append(branch_order_plen[order])
+                        path_lengths=path_length(apical, path, dist)
+                        branch_order_plengths=branch_order_plength(apical, branch_order_apical, branch_order_max_apical, path_lengths)
+                        results['apical_path_length_per_branch_order'] = branch_order_plengths
+                        for order in branch_order_plengths:
+                                average_apical_branch_order_plength[order].append(branch_order_plengths[order])
         
                 sholl_all_length=sholl_length(points, parental_points, soma_index, radius, [3,4])
                 results['sholl_all_length'] = sholl_all_length
@@ -849,11 +849,11 @@ def edit_main(argv=None):
             target_random_ratio = args.random_ratio / 100.0
         else:
             target_random_ratio = None
-        who_manual_variable = args.who_manual_variable
+        manual_dendrites = args.manual_dendrites
         action = args.action
-        hm_choice = args.hm_choice
+        extent_unit = args.extent_unit
         amount = args.amount
-        var_choice = args.var_choice
+        diam_unit = args.diam_unit
         diam_change = args.diam_change
     
     
@@ -879,11 +879,11 @@ def edit_main(argv=None):
             axon_bpoints,
             basal_bpoints,
             apical_bpoints,
-            else_bpoints,
+            soma_bpoints,
             soma_index,
             max_index,
             dendrite_list,
-            descendants,
+            subtrees,
             dend_indices,
             dend_names,
             axon,
@@ -929,7 +929,7 @@ def edit_main(argv=None):
         elif target_dendrites in random_map:
             target_dendrites, which_dendrites = sample_random_dendrites(*random_map[target_dendrites])
         elif target_dendrites == 'who_manual':
-            dendrites = [d for d in who_manual_variable.split(',') if d]
+            dendrites = [d for d in manual_dendrites.split(',') if d]
             target_dendrites = [int(x) for x in dendrites]
             which_dendrites = 'manually selected '
         else:
@@ -944,7 +944,7 @@ def edit_main(argv=None):
         (branch_order_freq, branch_order_max)=branch_order_frequency(dendrite_list, branch_order_map)
         
         if action == 'shrink':
-            if hm_choice == 'micrometers':
+            if extent_unit == 'micrometers':
                     (status, not_applicable)=shrink_warning(target_dendrites, dist, amount)
                     if status:
                             print('Consider these warnings before you proceed to shrink action!\n')
@@ -956,9 +956,9 @@ def edit_main(argv=None):
         
         print('\nRemodeling the neuron begins!\n')
         
-        edit='#REMOD edited the original ' + str(file_name) + ' file as follows: ' + str(which_dendrites) + 'dendrites: ' + str(target_dendrites) + ', action: ' + str(action) + ', extent percent/um: ' + str(hm_choice) + ', amount: ' + str(amount) + ', diameter percent/um: ' + str(var_choice) + ', diameter change: ' + str(diam_change) + " - This file was modified on " + str(now.strftime("%Y-%m-%d %H:%M")) + '\n#'
-        
-        (newfile, dendrite_list, segment_list)=execute_action(target_dendrites, action, amount, hm_choice, dend_segments, dist, max_index, diam_change, dendrite_list, soma_index, points, parental_points, descendants, all_terminal) #executes the selected action and print the modified tree to a '*_new.hoc' file
+        edit='#REMOD edited the original ' + str(file_name) + ' file as follows: ' + str(which_dendrites) + 'dendrites: ' + str(target_dendrites) + ', action: ' + str(action) + ', extent percent/um: ' + str(extent_unit) + ', amount: ' + str(amount) + ', diameter percent/um: ' + str(diam_unit) + ', diameter change: ' + str(diam_change) + " - This file was modified on " + str(now.strftime("%Y-%m-%d %H:%M")) + '\n#'
+
+        (newfile, dendrite_list, segment_list)=execute_action(target_dendrites, action, amount, extent_unit, dend_segments, dist, max_index, diam_change, dendrite_list, soma_index, points, parental_points, subtrees, all_terminal) #executes the selected action and print the modified tree to a '*_new.hoc' file
 
         if action in ['shrink', 'remove', 'scale']:
             newfile=index_reassign(dendrite_list, dend_segments, branch_order_map, connectivity_map, axon, basal, apical, undefined_dendrites, soma_index, branch_order_max, action)
@@ -977,11 +977,11 @@ def edit_main(argv=None):
             axon_bpoints,
             basal_bpoints,
             apical_bpoints,
-            else_bpoints,
+            soma_bpoints,
             soma_index,
             max_index,
             dendrite_list,
-            descendants,
+            subtrees,
             dend_indices,
             dend_names,
             axon,
@@ -1033,10 +1033,10 @@ def main(argv=None):
             '--file-name', args.file_name,
             '--who', args.who,
             '--random-ratio', str(args.random_ratio),
-            '--who-manual-variable', args.who_manual_variable,
+            '--who-manual-variable', args.manual_dendrites,
             '--action', args.action,
-            '--hm-choice', args.hm_choice,
-            '--var-choice', args.var_choice,
+            '--hm-choice', args.extent_unit,
+            '--var-choice', args.diam_unit,
         ]
         if args.amount is not None:
             arglist.extend(['--amount', str(args.amount)])

--- a/statistics_swc.py
+++ b/statistics_swc.py
@@ -80,10 +80,10 @@ def branch_order_dlength(dendrite_list, branch_order, branch_order_max, dist):
         # Groups lengths by branch order then averages them
         return _mean_by_branch_order(dendrite_list, branch_order, dist)
 
-def branch_order_plength(dendrite_list, branch_order, branch_order_max, plength):
+def branch_order_plength(dendrite_list, branch_order, branch_order_max, path_lengths):
         """Return average path length per branch order."""
         # Path lengths are summed for each order before averaging
-        return _mean_by_branch_order(dendrite_list, branch_order, plength)
+        return _mean_by_branch_order(dendrite_list, branch_order, path_lengths)
 
 def sholl_intersections(points, parental_points, soma_index, radius, parameter):
         """Compute Sholl intersection counts for the given radius."""

--- a/take_action.py
+++ b/take_action.py
@@ -142,18 +142,18 @@ def add_random_point(
 
     return new_point, length
 
-def translate_descendants(
+def translate_subtrees(
     translation_vector: Iterable[float],
     dendrite: int,
-    descendants: Dict[int, List[int]],
+    subtrees: Dict[int, List[int]],
     dendrites: Dict[int, List[List[Any]]],
 ) -> Dict[int, List[List[Any]]]:
-    """Translate descendant dendrites by ``translation_vector``."""
+    """Translate subtree dendrites by ``translation_vector``."""
     # Needed when shortening or removing upstream segments
 
     x, y, z = translation_vector
 
-    for child in descendants[dendrite]:
+    for child in subtrees[dendrite]:
         for i in range(len(dendrites[child])):
             dendrites[child][i][2] -= x
             dendrites[child][i][3] -= y
@@ -240,13 +240,13 @@ def shrink(
     target_dendrites,
     action,
     amount,
-    hm_choice,
+    extent_unit,
     dend_segments,
     dist,
     soma_index,
     points,
     parental_points,
-    descendants,
+    subtrees,
     all_terminal,
 ):
         """Return SWC lines with the selected dendrites shortened."""
@@ -282,10 +282,10 @@ def shrink(
                 segment_list=[]
                 cumulative_distance=step[dend]
 
-                if hm_choice=='percent':
+                if extent_unit=='percent':
                         new_dist[dend]=dist[dend]*((100-float(amount))/100)
 
-                if hm_choice=='micrometers':
+                if extent_unit=='micrometers':
                         new_dist[dend]=dist[dend]-float(amount)
 
                 if len(dend_segments[dend])>1:
@@ -366,8 +366,8 @@ def shrink(
 
                         vec=[initial_position[2]-final_position[2], initial_position[3]-final_position[3], initial_position[4]-final_position[4]]
                         translation_vec = tuple(vec)
-                        dend_segments = translate_descendants(
-                            translation_vec, dend, descendants, dend_segments
+                        dend_segments = translate_subtrees(
+                            translation_vec, dend, subtrees, dend_segments
                         )
 
         segment_list=[]
@@ -385,7 +385,7 @@ def shrink(
 
         return newfile
 
-'''def shrink(target_dendrites, action, amount, hm_choice, dend_segments, dist, soma_index, points, parental_points): #returns the new lines of the .hoc file with the selected dendrites shrinked
+'''def shrink(target_dendrites, action, amount, extent_unit, dend_segments, dist, soma_index, points, parental_points): #returns the new lines of the .hoc file with the selected dendrites shrinked
 
         amount=int(amount)
 
@@ -433,10 +433,10 @@ def shrink(
 
                 cumulative_distance+=distance(x,xp,y,yp,z,zp)
 
-                if hm_choice=='percent':
+                if extent_unit=='percent':
                         new_dist[dend]=dist[dend]*((100-amount)/100)
 
-                if hm_choice=='micrometers':
+                if extent_unit=='micrometers':
                         new_dist[dend]=dist[dend]-amount
 
                 segment_list=[]
@@ -565,7 +565,7 @@ def remove(
     soma_index,
     points,
     parental_points,
-    descendants,
+    subtrees,
     all_terminal,
 ):
         """Return SWC lines with the selected dendrites removed."""
@@ -577,7 +577,7 @@ def remove(
 
         for dend in target_dendrites:
                 if dend not in all_terminal:
-                        for d in descendants[dend]:
+                        for d in subtrees[dend]:
                                 if d not in target_dendrites:
                                         target_dendrites.append(d)
 
@@ -606,14 +606,14 @@ def extend(
     target_dendrites,
     action,
     amount,
-    hm_choice,
+    extent_unit,
     dend_segments,
     dist,
     max_index,
     soma_index,
     points,
     parental_points,
-    descendants,
+    subtrees,
     all_terminal,
 ):
         """Return SWC lines with the selected dendrites extended."""
@@ -660,10 +660,10 @@ def extend(
                         else:
                                 run_length+=1
 
-                if hm_choice=='percent':
+                if extent_unit=='percent':
                         new_dist[dend]=dist[dend]*float(amount)/100
 
-                if hm_choice=='micrometers':
+                if extent_unit=='micrometers':
                         new_dist[dend]=float(amount)
 
                 if len(dend_segments[dend])==1:
@@ -714,8 +714,8 @@ def extend(
 
                         vec=[initial_position[2]-final_position[2], initial_position[3]-final_position[3], initial_position[4]-final_position[4]]
                         translation_vec = tuple(vec)
-                        dend_segments = translate_descendants(
-                            translation_vec, dend, descendants, dend_segments
+                        dend_segments = translate_subtrees(
+                            translation_vec, dend, subtrees, dend_segments
                         )
 
                         dend_segments[change_these[0]][0][6]=dend_segments[dend][-1][0]
@@ -739,7 +739,7 @@ def branch(
     target_dendrites,
     action,
     amount,
-    hm_choice,
+    extent_unit,
     dend_segments,
     dist,
     max_index,
@@ -777,10 +777,10 @@ def branch(
                 new_point_a=[new_dend_a, point2[1], new_point[0][0], new_point[0][1], new_point[0][2], point2[5], dend_segments[dend][-1][0]]
                 new_point_b=[new_dend_b, point2[1], new_point[1][0], new_point[1][1], new_point[1][2], point2[5], dend_segments[dend][-1][0]]
 
-                if hm_choice=='percent':
+                if extent_unit=='percent':
                         new_dist[new_dend_a]=dist[dend]*amount/100
 
-                if hm_choice=='micrometers':
+                if extent_unit=='micrometers':
                         new_dist[new_dend_a]=amount
 
                 point1=new_point_a
@@ -800,10 +800,10 @@ def branch(
                 add_these_lines[new_dend_a].insert(0, new_point_a)
                 dend_segments[new_dend_a]=dend_segments[dend]+add_these_lines[new_dend_a]
 
-                if hm_choice=='percent':
+                if extent_unit=='percent':
                         new_dist[new_dend_b]=dist[dend]*amount/100
 
-                if hm_choice=='micrometers':
+                if extent_unit=='micrometers':
                         new_dist[new_dend_b]=amount
 
                 point1=new_point_b
@@ -911,14 +911,14 @@ def _build_actions(
     target_dendrites: Iterable[int],
     action: str,
     amount: Any,
-    hm_choice: str,
+    extent_unit: str,
     dend_segments: Dict[int, List[List[Any]]],
     dist: Dict[int, float],
     max_index: int,
     soma_index: List[List[Any]],
     points: Dict[int, List[Any]],
     parental_points: Dict[int, int],
-    descendants: Dict[int, List[int]],
+    subtrees: Dict[int, List[int]],
     all_terminal: List[int],
     dendrite_list: List[int],
 ) -> Tuple[Dict[str, ActionFunc], BranchFunc]:
@@ -931,13 +931,13 @@ def _build_actions(
                 target_dendrites,
                 action,
                 amount,
-                hm_choice,
+                extent_unit,
                 dend_segments,
                 dist,
                 soma_index,
                 points,
                 parental_points,
-                descendants,
+                subtrees,
                 all_terminal,
             ),
             "remove": lambda: remove(
@@ -947,21 +947,21 @@ def _build_actions(
                 soma_index,
                 points,
                 parental_points,
-                descendants,
+                subtrees,
                 all_terminal,
             ),
             "extend": lambda: extend(
                 target_dendrites,
                 action,
                 amount,
-                hm_choice,
+                extent_unit,
                 dend_segments,
                 dist,
                 max_index,
                 soma_index,
                 points,
                 parental_points,
-                descendants,
+                subtrees,
                 all_terminal,
             ),
             "scale": lambda: scale(target_dendrites, soma_index, dend_segments, amount),
@@ -970,7 +970,7 @@ def _build_actions(
             target_dendrites,
             action,
             amount,
-            hm_choice,
+            extent_unit,
             dend_segments,
             dist,
             max_index,
@@ -984,7 +984,7 @@ def execute_action(
     target_dendrites: Iterable[int],
     action: str,
     amount: Any,
-    hm_choice: str,
+    extent_unit: str,
     dend_segments: Dict[int, List[List[Any]]],
     dist: Dict[int, float],
     max_index: int,
@@ -993,7 +993,7 @@ def execute_action(
     soma_index: List[List[Any]],
     points: Dict[int, List[Any]],
     parental_points: Dict[int, int],
-    descendants: Dict[int, List[int]],
+    subtrees: Dict[int, List[int]],
     all_terminal: List[int],
 ) -> Tuple[List[str], List[int], List[List[Any]]]:
     """Execute a remodeling action and optionally change diameters."""
@@ -1007,14 +1007,14 @@ def execute_action(
             target_dendrites,
             action,
             amount,
-            hm_choice,
+            extent_unit,
             dend_segments,
             dist,
             max_index,
             soma_index,
             points,
             parental_points,
-            descendants,
+            subtrees,
             all_terminal,
             dendrite_list,
         )

--- a/utils.py
+++ b/utils.py
@@ -147,12 +147,14 @@ def parse_edit_args(args: list[str] | None = None):
                         help="Ratio for random selection (percent)")
     parser.add_argument(
         "--who-manual-variable",
+        dest="manual_dendrites",
         default="none",
         help="Comma separated manual dendrite ids",
     )
     parser.add_argument("--action", required=True, help="Remodeling action")
     parser.add_argument(
         "--hm-choice",
+        dest="extent_unit",
         required=True,
         help="percent or micrometers for extent",
     )
@@ -164,6 +166,7 @@ def parse_edit_args(args: list[str] | None = None):
     )
     parser.add_argument(
         "--var-choice",
+        dest="diam_unit",
         required=True,
         help="percent or micrometers for diameter change",
     )


### PR DESCRIPTION
## Summary
- rename poorly chosen variables across modules
- update argument parser names
- update call sites for renamed functions and variables

## Testing
- `python -m py_compile *.py`
