### PR TITLE
Refactor confusing variable names

### DIFF
--- a/index_reassignment.py
+++ b/index_reassignment.py
@@ -18,7 +18,7 @@ def _sorted_dendrites(dendrites: Iterable[int], branch_order: Dict[int, int]) ->
 
 def _renumber_dendrite(
     dend_id: int,
-    dend_segments: Dict[int, List[List[float]]],
+    dend_coords: Dict[int, List[List[float]]],
     branch_order: Dict[int, int],
     connectivity: Dict[int, int],
     start_index: int,
@@ -30,7 +30,7 @@ def _renumber_dendrite(
     ----------
     dend_id : int
         Identifier of the dendrite to renumber.
-    dend_segments : Dict[int, List[List[float]]]
+    dend_coords : Dict[int, List[List[float]]]
         Mapping from dendrite id to its list of segments.
     branch_order : Dict[int, int]
         Branch order of every dendrite.
@@ -49,7 +49,7 @@ def _renumber_dendrite(
     # Walk through the dendrite and assign new sequential indices
 
     order = branch_order[dend_id]
-    dend = dend_segments[dend_id]
+    dend = dend_coords[dend_id]
 
     previous = None
     for i, point in enumerate(dend):
@@ -61,7 +61,7 @@ def _renumber_dendrite(
                 point[6] = 1
             else:
                 parent_dend = connectivity[original_idx]
-                parent_point = dend_segments[parent_dend][-1]
+                parent_point = dend_coords[parent_dend][-1]
                 point[6] = parent_point[0]
         else:
             point[6] = previous
@@ -75,14 +75,14 @@ def _renumber_dendrite(
 
 def index_reassign(
     dendrite_list: Iterable[int],  # unused parameter maintained for compatibility
-    dend_segments: Dict[int, List[List[float]]],
+    dend_coords: Dict[int, List[List[float]]],
     branch_order_map: Dict[int, int],
     connectivity_map: Dict[int, int],
     axon: Iterable[int],
     basal: Iterable[int],
     apical: Iterable[int],
     undefined_dendrites: Iterable[int],
-    soma_index: List[List[float]],
+    soma_segments: List[List[float]],
     branch_order_max: int,
     action: str,
 ) -> List[str]:
@@ -98,7 +98,7 @@ def index_reassign(
 
     # Renumber soma segments first
     previous = None
-    for i, soma_pt in enumerate(soma_index):
+    for i, soma_pt in enumerate(soma_segments):
         soma_pt[0] = next_index
         soma_pt[6] = -1 if i == 0 else previous
         previous = next_index
@@ -110,7 +110,7 @@ def index_reassign(
     for dend_group in groups:
         for dend_id in _sorted_dendrites(dend_group, branch_order_map):
             next_index = _renumber_dendrite(
-                dend_id, dend_segments, branch_order_map, connectivity_map, next_index, segments
+                dend_id, dend_coords, branch_order_map, connectivity_map, next_index, segments
             )
 
     # Convert to SWC text lines

--- a/neuron_visualization.py
+++ b/neuron_visualization.py
@@ -36,7 +36,7 @@ def _soma_connections(soma_points: Sequence[Sequence]) -> Iterator[List]:
 
 def _dendrite_connections(
     dendrite_list: Iterable[int],
-    dend_segments: Dict[int, Sequence[Sequence]],
+    dend_coords: Dict[int, Sequence[Sequence]],
     points: Dict[int, Sequence],
     parent_indices: Dict[int, int],
 ) -> List[List]:
@@ -44,7 +44,7 @@ def _dendrite_connections(
     # Skips axon points which are marked with type 2
 
     for dend in dendrite_list:
-        for point in dend_segments[dend]:
+        for point in dend_coords[dend]:
             parent_idx = parent_indices.get(point[6], -1)
             if parent_idx == -1 or point[1] == 2:
                 continue
@@ -63,19 +63,19 @@ def _dendrite_connections(
 
 def _collect_segments(
     dendrite_list: Iterable[int],
-    dend_segments: Dict[int, Sequence[Sequence]],
+    dend_coords: Dict[int, Sequence[Sequence]],
     points: Dict[int, Sequence],
     parent_indices: Dict[int, int],
-    soma_index: Sequence[Sequence],
+    soma_segments: Sequence[Sequence],
 ) -> List[List]:
     """Gather all line segments for soma and dendrites."""
     # Internally chains helpers for cleaner export functions
 
     return list(
         chain(
-            _soma_connections(soma_index),
+            _soma_connections(soma_segments),
             _dendrite_connections(
-                dendrite_list, dend_segments, points, parent_indices
+                dendrite_list, dend_coords, points, parent_indices
             ),
         )
     )
@@ -85,10 +85,10 @@ def _export_graph(
     abs_path: Path | str,
     file_name: str,
     dendrite_list: Iterable[int],
-    dend_segments: Dict[int, Sequence[Sequence]],
+    dend_coords: Dict[int, Sequence[Sequence]],
     points: Dict[int, Sequence],
     parent_indices: Dict[int, int],
-    soma_index: Sequence[Sequence],
+    soma_segments: Sequence[Sequence],
     suffix: str,
     verbose: bool = False,
 ) -> None:
@@ -96,7 +96,7 @@ def _export_graph(
     # Build the list of line segments and write them to disk
 
     segments = _collect_segments(
-        dendrite_list, dend_segments, points, parent_indices, soma_index
+        dendrite_list, dend_coords, points, parent_indices, soma_segments
     )
 
     if verbose:
@@ -111,10 +111,10 @@ def first_graph(
     abs_path: Path | str,
     file_name: str,
     dendrite_list: Iterable[int],
-    dend_segments: Dict[int, Sequence[Sequence]],
+    dend_coords: Dict[int, Sequence[Sequence]],
     points: Dict[int, Sequence],
     parent_indices: Dict[int, int],
-    soma_index: Sequence[Sequence],
+    soma_segments: Sequence[Sequence],
 ) -> None:
     """Write coordinates of the original morphology to ``*_before.txt``."""
     # Called before any edits are applied
@@ -123,10 +123,10 @@ def first_graph(
         abs_path,
         file_name,
         dendrite_list,
-        dend_segments,
+        dend_coords,
         points,
         parent_indices,
-        soma_index,
+        soma_segments,
         "before",
     )
 
@@ -134,10 +134,10 @@ def second_graph(
     abs_path: Path | str,
     file_name: str,
     dendrite_list: Iterable[int],
-    dend_segments: Dict[int, Sequence[Sequence]],
+    dend_coords: Dict[int, Sequence[Sequence]],
     points: Dict[int, Sequence],
     parent_indices: Dict[int, int],
-    soma_index: Sequence[Sequence],
+    soma_segments: Sequence[Sequence],
 ) -> None:
     """Write coordinates of the edited morphology to ``*_after.txt``."""
     # Generates output after remodeling for comparison
@@ -146,10 +146,10 @@ def second_graph(
         abs_path,
         file_name,
         dendrite_list,
-        dend_segments,
+        dend_coords,
         points,
         parent_indices,
-        soma_index,
+        soma_segments,
         "after",
         verbose=True,
     )

--- a/run.py
+++ b/run.py
@@ -188,23 +188,22 @@ def analyze_main(argv=None):
                     swc_lines,
                     points,
                     comment_lines,
-                    parents,
                     branch_points,
                     axon_bpoints,
                     basal_bpoints,
                     apical_bpoints,
                     soma_bpoints,
-                    soma_index,
+                    soma_segments,
                     max_index,
                     dendrite_list,
-                    subtrees,
+                    descendants,
                     dend_indices,
                     dend_names,
                     axon,
                     basal,
                     apical,
                     undefined_dendrites,
-                    dend_segments,
+                    dend_coords,
                     path,
                     all_terminal,
                     basal_terminal,
@@ -215,7 +214,7 @@ def analyze_main(argv=None):
                     connectivity_map,
                     parent_indices,
                 ) = read_file(fname)  # extracts important connectivity and morphological data
-                first_graph(directory, file_name, dendrite_list, dend_segments, points, parent_indices,soma_index) #plots the original and modified tree (overlaying one another)
+                first_graph(directory, file_name, dendrite_list, dend_coords, points, parent_indices,soma_segments) #plots the original and modified tree (overlaying one another)
         
                 results['number_of_all_dendrites'] = len(dendrite_list)
                 average_number_of_all_dendrites.append(len(dendrite_list))
@@ -263,7 +262,7 @@ def analyze_main(argv=None):
                 #print len(list(set([parent_indices[x] for x in branch_points])))
         
                 fnum_all_bpoints = stats_dir / f'{file_name}_number_of_all_branchpoints.txt'
-                soma=[x[0] for x in soma_index]
+                soma=[x[0] for x in soma_segments]
                 write_value(
                     fnum_all_bpoints,
                     len(list(set([parent_indices[x] for x in branch_points if parent_indices[x] not in soma]))),
@@ -372,22 +371,22 @@ def analyze_main(argv=None):
                         for order in branch_order_plengths:
                                 average_apical_branch_order_plength[order].append(branch_order_plengths[order])
         
-                sholl_all_length=sholl_length(points, parent_indices, soma_index, radius, [3,4])
+                sholl_all_length=sholl_length(points, parent_indices, soma_segments, radius, [3,4])
                 results['sholl_all_length'] = sholl_all_length
                 for length in sorted(sholl_all_length):
                         average_sholl_all_length[length].append(sholl_all_length[length])
         
-                sholl_basal_length=sholl_length(points, parent_indices, soma_index, radius, [3])
+                sholl_basal_length=sholl_length(points, parent_indices, soma_segments, radius, [3])
                 results['sholl_basal_length'] = sholl_basal_length
                 for length in sorted(sholl_basal_length):
                         average_sholl_basal_length[length].append(sholl_basal_length[length])
         
-                sholl_apical_length=sholl_length(points, parent_indices, soma_index, radius, [4])
+                sholl_apical_length=sholl_length(points, parent_indices, soma_segments, radius, [4])
                 results['sholl_apical_length'] = sholl_apical_length
                 for length in sorted(sholl_apical_length):
                         average_sholl_apical_length[length].append(sholl_apical_length[length])
         
-                '''sholl_median_basal_length=sholl_length(points, parent_indices, soma_index, radius, [3])
+                '''sholl_median_basal_length=sholl_length(points, parent_indices, soma_segments, radius, [3])
                 f_sholl=os.path.join(stats_dir, file_name + '_sholl_median_basal_length.txt')
                 f = open(f_sholl, 'w+')
                 for length in sorted(sholl_median_basal_length):
@@ -395,17 +394,17 @@ def analyze_main(argv=None):
                         print >>f, "%s %s" % (length, sholl_median_basal_length[length])
                 f.close'''
         
-                sholl_all_bp=sholl_bp(branch_points, points, soma_index, radius)
+                sholl_all_bp=sholl_bp(branch_points, points, soma_segments, radius)
                 results['sholl_all_branchpoints'] = sholl_all_bp
                 for length in sorted(sholl_all_bp):
                         average_sholl_all_bp[length].append(sholl_all_bp[length])
         
-                sholl_basal_bp=sholl_bp(basal_bpoints, points, soma_index, radius)
+                sholl_basal_bp=sholl_bp(basal_bpoints, points, soma_segments, radius)
                 results['sholl_basal_branchpoints'] = sholl_basal_bp
                 for length in sorted(sholl_basal_bp):
                         average_sholl_basal_bp[length].append(sholl_basal_bp[length])
         
-                sholl_apical_bp=sholl_bp(apical_bpoints, points, soma_index, radius)
+                sholl_apical_bp=sholl_bp(apical_bpoints, points, soma_segments, radius)
                 results['sholl_apical_branchpoints'] = sholl_apical_bp
                 for length in sorted(sholl_apical_bp):
                         average_sholl_apical_bp[length].append(sholl_apical_bp[length])
@@ -416,7 +415,7 @@ def analyze_main(argv=None):
                 f.close'''
         
                 vector=[]
-                sholl_all_intersections=sholl_intersections(points, parent_indices, soma_index, radius, [3,4])
+                sholl_all_intersections=sholl_intersections(points, parent_indices, soma_segments, radius, [3,4])
                 results['sholl_all_intersections'] = sholl_all_intersections
                 for length in sorted(sholl_all_intersections):
                         average_sholl_all_intersections[length].append(sholl_all_intersections[length])
@@ -425,7 +424,7 @@ def analyze_main(argv=None):
                         vector.append(sholl_all_intersections[length])
         
                 vector=[]
-                sholl_basal_intersections=sholl_intersections(points, parent_indices, soma_index, radius, [3])
+                sholl_basal_intersections=sholl_intersections(points, parent_indices, soma_segments, radius, [3])
                 results['sholl_basal_intersections'] = sholl_basal_intersections
                 for length in sorted(sholl_basal_intersections):
                         average_sholl_basal_intersections[length].append(sholl_basal_intersections[length])
@@ -434,7 +433,7 @@ def analyze_main(argv=None):
                         vector.append(sholl_basal_intersections[length])
         
                 vector=[]
-                sholl_apical_intersections=sholl_intersections(points, parent_indices, soma_index, radius, [4])
+                sholl_apical_intersections=sholl_intersections(points, parent_indices, soma_segments, radius, [4])
                 results['sholl_apical_intersections'] = sholl_apical_intersections
                 for length in sorted(sholl_apical_intersections):
                         average_sholl_apical_intersections[length].append(sholl_apical_intersections[length])
@@ -874,23 +873,22 @@ def edit_main(argv=None):
             swc_lines,
             points,
             comment_lines,
-            parents,
             branch_points,
             axon_bpoints,
             basal_bpoints,
             apical_bpoints,
             soma_bpoints,
-            soma_index,
+            soma_segments,
             max_index,
             dendrite_list,
-            subtrees,
+            descendants,
             dend_indices,
             dend_names,
             axon,
             basal,
             apical,
             undefined_dendrites,
-            dend_segments,
+            dend_coords,
             path,
             all_terminal,
             basal_terminal,
@@ -958,10 +956,10 @@ def edit_main(argv=None):
         
         edit='#REMOD edited the original ' + str(file_name) + ' file as follows: ' + str(which_dendrites) + 'dendrites: ' + str(target_dendrites) + ', action: ' + str(action) + ', extent percent/um: ' + str(extent_unit) + ', amount: ' + str(amount) + ', diameter percent/um: ' + str(diam_unit) + ', diameter change: ' + str(diam_change) + " - This file was modified on " + str(now.strftime("%Y-%m-%d %H:%M")) + '\n#'
 
-        (newfile, dendrite_list, segment_list)=execute_action(target_dendrites, action, amount, extent_unit, dend_segments, dist, max_index, diam_change, dendrite_list, soma_index, points, parent_indices, subtrees, all_terminal) #executes the selected action and print the modified tree to a '*_new.hoc' file
+        (newfile, dendrite_list, segment_list)=execute_action(target_dendrites, action, amount, extent_unit, dend_coords, dist, max_index, diam_change, dendrite_list, soma_segments, points, parent_indices, descendants, all_terminal) #executes the selected action and print the modified tree to a '*_new.hoc' file
 
         if action in ['shrink', 'remove', 'scale']:
-            newfile=index_reassign(dendrite_list, dend_segments, branch_order_map, connectivity_map, axon, basal, apical, undefined_dendrites, soma_index, branch_order_max, action)
+            newfile=index_reassign(dendrite_list, dend_coords, branch_order_map, connectivity_map, axon, basal, apical, undefined_dendrites, soma_segments, branch_order_max, action)
         
         newfile=comment_lines + newfile
         check_indices(newfile) #check if indices are continuous from 0 and u
@@ -972,23 +970,22 @@ def edit_main(argv=None):
             swc_lines,
             points,
             comment_lines,
-            parents,
             branch_points,
             axon_bpoints,
             basal_bpoints,
             apical_bpoints,
             soma_bpoints,
-            soma_index,
+            soma_segments,
             max_index,
             dendrite_list,
-            subtrees,
+            descendants,
             dend_indices,
             dend_names,
             axon,
             basal,
             apical,
             undefined_dendrites,
-            dend_segments,
+            dend_coords,
             path,
             all_terminal,
             basal_terminal,
@@ -999,7 +996,7 @@ def edit_main(argv=None):
             connectivity_map,
             parent_indices,
         ) = read_file(fname)
-        second_graph(directory, file_name, dendrite_list, dend_segments, points, parent_indices, soma_index) #plots the original and modified tree (overlaying one another)
+        second_graph(directory, file_name, dendrite_list, dend_coords, points, parent_indices, soma_segments) #plots the original and modified tree (overlaying one another)
         
         print()
         print('File: ' + str(file_name) + ' was succesfully edited!')
@@ -1009,7 +1006,7 @@ def edit_main(argv=None):
         print()
     
     
-        #graph(swc_lines, newfile, action, dend_segments, dendrite_list, directory, file_name) #plots the original and modified tree (overlaying one another)
+        #graph(swc_lines, newfile, action, dend_coords, dendrite_list, directory, file_name) #plots the original and modified tree (overlaying one another)
     
     
 def main(argv=None):

--- a/utils.py
+++ b/utils.py
@@ -52,11 +52,11 @@ def weighted_sample(population: Sequence, weights: Sequence[float], k: int):
 def sample_random_dendrites(
     options: Sequence[int],
     label: str,
-    dend_segments: dict[int, Sequence],
+    dend_coords: dict[int, Sequence],
     ratio: float,
 ) -> tuple[list[int], str]:
     """Return a random selection of dendrites respecting ``ratio``."""
-    valid = [d for d in options if len(dend_segments[d]) >= 3]
+    valid = [d for d in options if len(dend_coords[d]) >= 3]
     num = int(round_to(len(valid) * ratio, 1))
     num = max(0, min(num, len(valid)))
     selection = random.sample(valid, num)


### PR DESCRIPTION
## Summary
- rename `soma_index` to `soma_segments`
- rename `dend_segments` to `dend_coords`
- rename `subtrees` to `descendants`
- rename `connection_to_parent` to `toward_soma_map`
- rename various temporary variables (point_one/two, newpoint, etc.)
- remove unused `parents` list

## Testing
- `python -m py_compile $(git ls-files '*.py')`