### PR TITLE
Rename variables to use radius terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Parse SWC files and compute branch counts, branch order distributions, path and total lengths, surface areas and Sholl measurements.
 - Automatically store aggregated statistics in `downloads/statistics/`.
-- Remodel morphologies via `run.py edit` to remove, shrink, extend, branch or scale dendrites.  Dendrites can be chosen manually or randomly and diameters can be adjusted.
+- Remodel morphologies via `run.py edit` to remove, shrink, extend, branch or scale dendrites.  Dendrites can be chosen manually or randomly and radii can be adjusted.
 - Node indices are renumbered automatically after editing.
 - Visualise original and modified trees with `neuron_visualization.py` or overlay plots from `graph.py`.
 - Generate summary graphs with `plot_data.py` and combine results from multiple runs using `merge_stats.py`.
@@ -42,7 +42,7 @@ Using a virtual environment is recommended but not mandatory.
       --hm-choice percent \
       --amount 50 \
       --var-choice percent \
-      --diam-change 10
+      --radius-change 10
    ```
 
    Other actions include `shrink`, `extend`, `branch` and `scale`.  Dendrites can be selected randomly using `--random-ratio` or specified explicitly with `--manual-dendrites`.

--- a/extract_swc_morphology.py
+++ b/extract_swc_morphology.py
@@ -27,7 +27,7 @@ def parse_swc_lines(swc_lines: Iterable[str]) -> Tuple[List[str], Dict[int, List
     -------
     tuple
         ``(comment_lines, points)`` where ``points`` maps segment index to the
-        list ``[i, t, x, y, z, d, parent]``.
+        list ``[i, t, x, y, z, radius, parent]``.
     """
 
     # Maintain original comments separately from numeric data
@@ -49,13 +49,13 @@ def parse_swc_lines(swc_lines: Iterable[str]) -> Tuple[List[str], Dict[int, List
             x = float(parts[2])
             y = float(parts[3])
             z = float(parts[4])
-            d = float(parts[5])
+            radius = float(parts[5])
             parent = int(parts[6])
         except ValueError:
             # Skip malformed lines
             continue
 
-        points[i] = [i, t, x, y, z, d, parent]
+        points[i] = [i, t, x, y, z, radius, parent]
 
     return comment_lines, points
 
@@ -296,9 +296,9 @@ def dendrite_areas(
         segs = [points[parent_indices[dend[0][0]]]] + dend
         contributions = []
         for a, b in zip(segs[:-1], segs[1:]):
-            diam = b[5]
+            radius = b[5]
             di = distance(a[2], b[2], a[3], b[3], a[4], b[4])
-            contributions.append(2 * pi * diam * di)
+            contributions.append(2 * pi * radius * di)
         area[idx] = sum(contributions)
 
     return area

--- a/run.py
+++ b/run.py
@@ -852,8 +852,8 @@ def edit_main(argv=None):
         action = args.action
         extent_unit = args.extent_unit
         amount = args.amount
-        diam_unit = args.diam_unit
-        diam_change = args.diam_change
+        radius_unit = args.radius_unit
+        radius_change = args.radius_change
     
     
         downloads_dir = directory / 'downloads'
@@ -954,9 +954,9 @@ def edit_main(argv=None):
         
         print('\nRemodeling the neuron begins!\n')
         
-        edit='#REMOD edited the original ' + str(file_name) + ' file as follows: ' + str(which_dendrites) + 'dendrites: ' + str(target_dendrites) + ', action: ' + str(action) + ', extent percent/um: ' + str(extent_unit) + ', amount: ' + str(amount) + ', diameter percent/um: ' + str(diam_unit) + ', diameter change: ' + str(diam_change) + " - This file was modified on " + str(now.strftime("%Y-%m-%d %H:%M")) + '\n#'
+        edit='#REMOD edited the original ' + str(file_name) + ' file as follows: ' + str(which_dendrites) + 'dendrites: ' + str(target_dendrites) + ', action: ' + str(action) + ', extent percent/um: ' + str(extent_unit) + ', amount: ' + str(amount) + ', radius percent/um: ' + str(radius_unit) + ', radius change: ' + str(radius_change) + " - This file was modified on " + str(now.strftime("%Y-%m-%d %H:%M")) + '\n#'
 
-        (new_lines, dendrite_list, segment_list)=execute_action(target_dendrites, action, amount, extent_unit, dend_coords, dist, max_index, diam_change, dendrite_list, soma_segments, points, parent_indices, descendants, all_terminal) #executes the selected action and print the modified tree to a '*_new.hoc' file
+        (new_lines, dendrite_list, segment_list)=execute_action(target_dendrites, action, amount, extent_unit, dend_coords, dist, max_index, radius_change, dendrite_list, soma_segments, points, parent_indices, descendants, all_terminal) #executes the selected action and print the modified tree to a '*_new.hoc' file
 
         if action in ['shrink', 'remove', 'scale']:
             new_lines=index_reassign(dendrite_list, dend_coords, branch_order_map, connectivity_map, axon, basal, apical, undefined_dendrites, soma_segments, branch_order_max, action)
@@ -1033,12 +1033,12 @@ def main(argv=None):
             '--manual-dendrites', args.manual_dendrites,
             '--action', args.action,
             '--hm-choice', args.extent_unit,
-            '--var-choice', args.diam_unit,
+            '--var-choice', args.radius_unit,
         ]
         if args.amount is not None:
             arglist.extend(['--amount', str(args.amount)])
-        if args.diam_change is not None:
-            arglist.extend(['--diam-change', str(args.diam_change)])
+        if args.radius_change is not None:
+            arglist.extend(['--radius-change', str(args.radius_change)])
         edit_main(arglist)
     else:
         print(f"Unknown command: {command}")

--- a/statistics_swc.py
+++ b/statistics_swc.py
@@ -49,14 +49,14 @@ def path_length(dendrite_list, path, dist):
 
         return {d: sum(dist[i] for i in path[d]) for d in dendrite_list}
 
-def median_diameter(dendrite_list, dend_coords):
-        """Return the median diameter for each dendrite in *dendrite_list*."""
-        # Diameter at the midpoint acts as a robust representative
-        med_diam = {}
+def median_radius(dendrite_list, dend_coords):
+        """Return the median radius for each dendrite in *dendrite_list*."""
+        # Radius at the midpoint acts as a robust representative
+        med_rad = {}
         for dend in dendrite_list:
                 mid_idx = len(dend_coords[dend]) // 2
-                med_diam[dend] = float(dend_coords[dend][mid_idx][5]) * 2
-        return med_diam
+                med_rad[dend] = float(dend_coords[dend][mid_idx][5])
+        return med_rad
 
 def print_branch_order(dendrite_list, branch_order):
         """Return a sorted list of (dendrite, branch_order) tuples."""
@@ -200,20 +200,20 @@ def dist_angle_frequency(dist_angle, radius):
 def axis(apical, dend_coords, soma_segments):
         # weighted linear regression
         """Return principal axis and soma location using weighted regression."""
-        # Weighted by diameter so thicker dendrites influence the fit
+        # Weighted by radius so thicker dendrites influence the fit
 
         x_soma, y_soma, z_soma = soma_segments[0][2], soma_segments[0][3], soma_segments[0][4]
 
         coords = []
-        diam = []
+        radii = []
         for dend in apical:
                 arr = np.array(dend_coords[dend])
                 coords.append(arr[:, 2:5] - [x_soma, y_soma, z_soma])
-                diam.append(arr[:, 5])
+                radii.append(arr[:, 5])
 
         coords = np.vstack(coords)
-        diam = np.hstack(diam)
-        weights = diam / diam.sum()
+        radii = np.hstack(radii)
+        weights = radii / radii.sum()
 
         weighted = coords * weights[:, None]
         centered = weighted - weighted.mean(axis=0)

--- a/utils.py
+++ b/utils.py
@@ -166,15 +166,15 @@ def parse_edit_args(args: list[str] | None = None):
     )
     parser.add_argument(
         "--var-choice",
-        dest="diam_unit",
+        dest="radius_unit",
         required=True,
-        help="percent or micrometers for diameter change",
+        help="percent or micrometers for radius change",
     )
     parser.add_argument(
-        "--diam-change",
+        "--radius-change",
         type=float,
         default=None,
-        help="Extent of diameter change",
+        help="Extent of radius change",
     )
     ns = parser.parse_args(args)
     if not ns.directory.is_dir():


### PR DESCRIPTION
## Summary
- rename variables and CLI options to use 'radius' instead of 'diameter'
- update statistics function to `median_radius`
- clean up variable names for clarity
- adjust README accordingly

## Testing
- `python -m py_compile *.py`