### PR TITLE
Refactor variable names for clarity

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -18,15 +18,15 @@ def build_plot_from_lines(lines: Iterable[str]) -> list[PlotEntry]:
     from extract_swc_morphology import parse_swc_lines
     from utils import round_to
 
-    _, points = parse_swc_lines(lines)
+    _, samples = parse_swc_lines(lines)
     plot: list[PlotEntry] = []
-    for idx, vals in points.items():
+    for idx, vals in samples.items():
         parent = int(vals[6])
-        if parent == -1 or parent not in points:
+        if parent == -1 or parent not in samples:
             continue
-        x = [round_to(float(vals[2]), 0.01), round_to(float(points[parent][2]), 0.01)]
-        y = [round_to(float(vals[3]), 0.01), round_to(float(points[parent][3]), 0.01)]
-        z = [round_to(float(vals[4]), 0.01), round_to(float(points[parent][4]), 0.01)]
+        x = [round_to(float(vals[2]), 0.01), round_to(float(samples[parent][2]), 0.01)]
+        y = [round_to(float(vals[3]), 0.01), round_to(float(samples[parent][3]), 0.01)]
+        z = [round_to(float(vals[4]), 0.01), round_to(float(samples[parent][4]), 0.01)]
         plot.append([x, y, z, float(vals[5])])
     return plot
 

--- a/index_reassignment.py
+++ b/index_reassignment.py
@@ -18,7 +18,7 @@ def _sorted_dendrites(dendrites: Iterable[int], branch_order: Dict[int, int]) ->
 
 def _renumber_dendrite(
     dend_id: int,
-    dend_coords: Dict[int, List[List[float]]],
+    dendrite_samples: Dict[int, List[List[float]]],
     branch_order: Dict[int, int],
     connectivity: Dict[int, int],
     start_index: int,
@@ -30,7 +30,7 @@ def _renumber_dendrite(
     ----------
     dend_id : int
         Identifier of the dendrite to renumber.
-    dend_coords : Dict[int, List[List[float]]]
+    dendrite_samples : Dict[int, List[List[float]]]
         Mapping from dendrite id to its list of samples.
     branch_order : Dict[int, int]
         Branch order of every dendrite.
@@ -49,7 +49,7 @@ def _renumber_dendrite(
     # Walk through the dendrite and assign new sequential indices
 
     order = branch_order[dend_id]
-    dend = dend_coords[dend_id]
+    dend = dendrite_samples[dend_id]
 
     previous = None
     for i, point in enumerate(dend):
@@ -61,7 +61,7 @@ def _renumber_dendrite(
                 point[6] = 1
             else:
                 parent_dend = connectivity[original_idx]
-                parent_point = dend_coords[parent_dend][-1]
+                parent_point = dendrite_samples[parent_dend][-1]
                 point[6] = parent_point[0]
         else:
             point[6] = previous
@@ -75,7 +75,7 @@ def _renumber_dendrite(
 
 def index_reassign(
     dendrite_list: Iterable[int],  # unused parameter maintained for compatibility
-    dend_coords: Dict[int, List[List[float]]],
+    dendrite_samples: Dict[int, List[List[float]]],
     branch_order_map: Dict[int, int],
     connectivity_map: Dict[int, int],
     axon: Iterable[int],
@@ -110,7 +110,7 @@ def index_reassign(
     for dend_group in groups:
         for dend_id in _sorted_dendrites(dend_group, branch_order_map):
             next_index = _renumber_dendrite(
-                dend_id, dend_coords, branch_order_map, connectivity_map, next_index, samples
+                dend_id, dendrite_samples, branch_order_map, connectivity_map, next_index, samples
             )
 
     # Convert to SWC text lines

--- a/statistics_swc.py
+++ b/statistics_swc.py
@@ -16,85 +16,85 @@ def _soma_coords(soma_samples):
     return np.array([soma[2], soma[3], soma[4]])
 
 
-def _coords(points, indices):
+def _coords(samples, indices):
     """Return a numpy array of xyz coordinates for ``indices``."""
     # Extract coordinates only once for efficiency
-    return np.array([[points[i][2], points[i][3], points[i][4]] for i in indices])
+    return np.array([[samples[i][2], samples[i][3], samples[i][4]] for i in indices])
 
 
-def _mean_by_branch_order(dendrite_list, branch_order, values):
+def _mean_by_branch_order(dendrite_roots, branch_order, values):
     """Return the mean of ``values`` grouped by branch order."""
     # Data for the same branch order are accumulated then averaged
     acc = defaultdict(list)
-    for dend in dendrite_list:
+    for dend in dendrite_roots:
         acc[branch_order[dend]].append(values[dend])
 
     return {k: sum(v) / len(v) for k, v in acc.items() if v}
 
-def total_length(dendrite_list, dist):
+def total_length(dendrite_roots, dist):
         # soma_included
-        """Return the total length of *dendrite_list* using ``dist`` mapping."""
+        """Return the total length of *dendrite_roots* using ``dist`` mapping."""
         # Each dendrite's precomputed length is summed
-        return sum(dist[d] for d in dendrite_list)
+        return sum(dist[d] for d in dendrite_roots)
 
-def total_area(dendrite_list, area):
+def total_area(dendrite_roots, area):
         # soma_included
-        """Return the total surface area of *dendrite_list* using ``area`` mapping."""
+        """Return the total surface area of *dendrite_roots* using ``area`` mapping."""
         # Aggregates surface areas returned by ``dendrite_areas``
-        return sum(area[d] for d in dendrite_list)
+        return sum(area[d] for d in dendrite_roots)
 
-def path_length(dendrite_list, path, dist):
+def path_length(dendrite_roots, path, dist):
         """Return a mapping of dendrite IDs to path length."""
         # Path length sums distances along the path to the soma
 
-        return {d: sum(dist[i] for i in path[d]) for d in dendrite_list}
+        return {d: sum(dist[i] for i in path[d]) for d in dendrite_roots}
 
-def median_radius(dendrite_list, dend_coords):
-        """Return the median radius for each dendrite in *dendrite_list*."""
+def median_radius(dendrite_roots, dendrite_samples):
+        """Return the median radius for each dendrite in *dendrite_roots*."""
         # Radius at the midpoint acts as a robust representative
         med_rad = {}
-        for dend in dendrite_list:
-                mid_idx = len(dend_coords[dend]) // 2
-                med_rad[dend] = float(dend_coords[dend][mid_idx][5])
+        for dend in dendrite_roots:
+                mid_idx = len(dendrite_samples[dend]) // 2
+                med_rad[dend] = float(dendrite_samples[dend][mid_idx][5])
         return med_rad
 
-def print_branch_order(dendrite_list, branch_order):
+def print_branch_order(dendrite_roots, branch_order):
         """Return a sorted list of (dendrite, branch_order) tuples."""
         # Useful for debugging the traversal order
-        branch_order_dict = {d: branch_order[d] for d in dendrite_list}
+        branch_order_dict = {d: branch_order[d] for d in dendrite_roots}
         return sorted(branch_order_dict.items(), key=lambda x: x[0])
 
-def branch_order_frequency(dendrite_list, branch_order):
+def branch_order_frequency(dendrite_roots, branch_order):
         """Return the frequency of each branch order."""
         # Counts how many dendrites occur at each order
 
-        orders = [branch_order[d] for d in dendrite_list]
+        orders = [branch_order[d] for d in dendrite_roots]
         counter = Counter(orders)
         branch_order_max = max(counter) if counter else 0
         branch_order_freq = {i: counter.get(i, 0) for i in range(1, branch_order_max + 1)}
 
         return branch_order_freq, branch_order_max
 
-def branch_order_dlength(dendrite_list, branch_order, branch_order_max, dist):
+def branch_order_dlength(dendrite_roots, branch_order, branch_order_max, dist):
         """Return average dendrite length per branch order."""
         # Groups lengths by branch order then averages them
-        return _mean_by_branch_order(dendrite_list, branch_order, dist)
+        return _mean_by_branch_order(dendrite_roots, branch_order, dist)
 
-def branch_order_path_length(dendrite_list, branch_order, branch_order_max, path_lengths):
+def branch_order_path_length(dendrite_roots, branch_order, branch_order_max, path_lengths):
         """Return average path length per branch order."""
         # Path lengths are summed for each order before averaging
-        return _mean_by_branch_order(dendrite_list, branch_order, path_lengths)
+        return _mean_by_branch_order(dendrite_roots, branch_order, path_lengths)
 
-def sholl_intersections(points, parent_samples, soma_samples, radius, parameter):
+def sholl_intersections(samples, parents, soma_samples, radius, parameter):
         """Compute Sholl intersection counts for the given radius."""
         # Measures crossings of concentric shells centred at the soma
 
         soma_coords = _soma_coords(soma_samples)
 
         values = np.arange(0, 10000, radius)
-        ids = [i for i in points if points[i][1] in parameter]
-        pts = _coords(points, ids)
-        parents = _coords(points, [parent_samples[i] for i in ids])
+        ids = [i for i in samples if samples[i][1] in parameter]
+        pts = _coords(samples, ids)
+        parents = _coords(samples, [parents[i] for i in ids])
 
         dist1 = np.linalg.norm(pts - soma_coords, axis=1)
         dist2 = np.linalg.norm(parents - soma_coords, axis=1)
@@ -106,14 +106,14 @@ def sholl_intersections(points, parent_samples, soma_samples, radius, parameter)
 
         return sholl_list
 
-def sholl_bp(branch_points, points, soma_samples, radius):
-        """Compute number of branch points crossing each Sholl shell."""
+def sholl_bp(branch_points, samples, soma_samples, radius):
+        """Compute number of branch samples crossing each Sholl shell."""
         # Each branch point is assigned to a radial distance bin
 
         soma_coords = _soma_coords(soma_samples)
 
         values = np.arange(0, 10000, radius)
-        pts = _coords(points, branch_points)
+        pts = _coords(samples, branch_points)
         dist = np.linalg.norm(pts - soma_coords, axis=1)
 
         sholl_list = {}
@@ -135,16 +135,16 @@ def remove_trailing_zeros(sholl_list, values, radius):
         return {values[i] + radius: sholl_list[values[i] + radius] for i in range(idx)}
 
 
-def sholl_length(points, parent_samples, soma_samples, radius, parameter):
+def sholl_length(samples, parents, soma_samples, radius, parameter):
         """Compute total dendrite length inside successive Sholl shells."""
         # Sums segment lengths that fall within each radial bin
 
         soma_coords = _soma_coords(soma_samples)
 
         values = np.arange(0, 10000, radius)
-        ids = [i for i in points if points[i][1] in parameter]
-        pts = _coords(points, ids)
-        parents = _coords(points, [parent_samples[i] for i in ids])
+        ids = [i for i in samples if samples[i][1] in parameter]
+        pts = _coords(samples, ids)
+        parents = _coords(samples, [parents[i] for i in ids])
 
         lengths = np.linalg.norm(pts - parents, axis=1)
         dist1 = np.linalg.norm(pts - soma_coords, axis=1)
@@ -156,8 +156,8 @@ def sholl_length(points, parent_samples, soma_samples, radius, parameter):
 
         return sholl_list
 
-def dist_angle_analysis(dendrite_list, dend_coords, soma_root, principal_axis):
-        """Return list of [distance, angle] pairs for dendrite points."""
+def dist_angle_analysis(dendrite_roots, dendrite_samples, soma_root, principal_axis):
+        """Return list of [distance, angle] pairs for dendrite samples."""
         # Calculates angle relative to the main apical axis
 
         soma_root = np.array(soma_root)
@@ -165,8 +165,8 @@ def dist_angle_analysis(dendrite_list, dend_coords, soma_root, principal_axis):
         axis_unit = axis_vec / LA.norm(axis_vec)
 
         dist_angle = []
-        for dend in dendrite_list:
-                coords = np.array(dend_coords[dend])[:, 2:5]
+        for dend in dendrite_roots:
+                coords = np.array(dendrite_samples[dend])[:, 2:5]
                 bc = coords - soma_root
                 dist = LA.norm(bc, axis=1)
                 bc_unit = bc / dist[:, None]
@@ -197,7 +197,7 @@ def dist_angle_frequency(dist_angle, radius):
 
         return dist_freq, angle_f
 
-def axis(apical, dend_coords, soma_samples):
+def axis(apical, dendrite_samples, soma_samples):
         # weighted linear regression
         """Return principal axis and soma location using weighted regression."""
         # Weighted by radius so thicker dendrites influence the fit
@@ -207,7 +207,7 @@ def axis(apical, dend_coords, soma_samples):
         coords = []
         radii = []
         for dend in apical:
-                arr = np.array(dend_coords[dend])
+                arr = np.array(dendrite_samples[dend])
                 coords.append(arr[:, 2:5] - [x_soma, y_soma, z_soma])
                 radii.append(arr[:, 5])
 

--- a/utils.py
+++ b/utils.py
@@ -52,11 +52,11 @@ def weighted_sample(population: Sequence, weights: Sequence[float], k: int):
 def sample_random_dendrites(
     options: Sequence[int],
     label: str,
-    dend_coords: dict[int, Sequence],
+    dendrite_samples: dict[int, Sequence],
     ratio: float,
 ) -> tuple[list[int], str]:
     """Return a random selection of dendrites respecting ``ratio``."""
-    valid = [d for d in options if len(dend_coords[d]) >= 3]
+    valid = [d for d in options if len(dendrite_samples[d]) >= 3]
     num = int(round_to(len(valid) * ratio, 1))
     num = max(0, min(num, len(valid)))
     selection = random.sample(valid, num)


### PR DESCRIPTION
## Summary
- rename SWC parsing variables to use official terminology
- update helper functions and call sites to new names
- adjust run scripts and utilities for renamed variables

## Testing
- `python -m py_compile extract_swc_morphology.py run.py take_action.py index_reassignment.py neuron_visualization.py graph.py statistics_swc.py utils.py`