### PR TITLE
Rename modules with clearer names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,12 +44,12 @@ paper_info.txt
 scale_down.py
 test.py
 tree_graph.txt
-extract_swc_morphology.pyc
-graph.pyc
-index_reassignment.pyc
+swc_parser.pyc
+overlay_graph.pyc
+reassign_indices.pyc
 neuron_before_swc.pyc
 plot_individual_data.pyc
 print_file.pyc
 random_sampling.pyc
-statistics_swc.pyc
+morphology_statistics.pyc
 warn.pyc

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 - Parse SWC files and compute branch counts, branch order distributions, path and total lengths, surface areas and Sholl measurements.
 - Automatically store aggregated statistics in `downloads/statistics/`.
-- Remodel morphologies via `run.py edit` to remove, shrink, extend, branch or scale dendrites.  Dendrites can be chosen manually or randomly and radii can be adjusted.
+- Remodel morphologies via `remod_cli.py edit` to remove, shrink, extend, branch or scale dendrites.  Dendrites can be chosen manually or randomly and radii can be adjusted.
 - Node indices are renumbered automatically after editing.
-- Visualise original and modified trees with `neuron_visualization.py` or overlay plots from `graph.py`.
-- Generate summary graphs with `plot_data.py` and combine results from multiple runs using `merge_stats.py`.
+- Visualise original and modified trees with `neuron_export.py` or overlay plots from `overlay_graph.py`.
+- Generate summary graphs with `plot_statistics.py` and combine results from multiple runs using `merge_statistics.py`.
 
 ## Installation
 
@@ -24,17 +24,17 @@ Using a virtual environment is recommended but not mandatory.
 ## Quick start
 
 1. **Prepare your SWC files** – place your `.swc` files in a directory. Example data are available under `swc_files/`.
-2. **Compute statistics** – run `run.py analyze` with the directory and a comma separated list of file names:
+2. **Compute statistics** – run `remod_cli.py analyze` with the directory and a comma separated list of file names:
 
    ```bash
-   python run.py analyze /path/to/swc 0-2.swc
+   python remod_cli.py analyze /path/to/swc 0-2.swc
    ```
 
    Results such as total dendritic length, branch order frequency and Sholl intersections are saved in `downloads/statistics/`.
-3. **Remodel a morphology** – use `run.py edit` to apply structural changes.  The example below removes 50% of all terminal dendrites from `0-2.swc` and writes the modified neuron to `downloads/files/0-2_new.swc`:
+3. **Remodel a morphology** – use `remod_cli.py edit` to apply structural changes.  The example below removes 50% of all terminal dendrites from `0-2.swc` and writes the modified neuron to `downloads/files/0-2_new.swc`:
 
    ```bash
-   python run.py edit \
+   python remod_cli.py edit \
       --directory /path/to/swc \
       --file-name 0-2.swc \
       --who all_terminal \
@@ -46,22 +46,22 @@ Using a virtual environment is recommended but not mandatory.
    ```
 
    Other actions include `shrink`, `extend`, `branch` and `scale`.  Dendrites can be selected randomly using `--random-ratio` or specified explicitly with `--manual-dendrites`.
-4. **Visualise** – run `neuron_visualization.py` or `graph.py` to generate 3‑D plots comparing the original and edited morphologies. Use `plot_data.py` on `downloads/statistics/` to create summary graphs; add `--average` or `--compare` for group averages or comparative views.  Figures are stored in the `downloads/` directory.
+4. **Visualise** – run `neuron_export.py` or `overlay_graph.py` to generate 3‑D plots comparing the original and edited morphologies. Use `plot_statistics.py` on `downloads/statistics/` to create summary graphs; add `--average` or `--compare` for group averages or comparative views.  Figures are stored in the `downloads/` directory.
 
 ## Workflow
 
 The typical pipeline is:
 
-1. **Analyse** – `run.py analyze` computes baseline statistics for a set of SWC files and writes them to `downloads/statistics/`.
-2. **Modify** – `run.py edit` applies the chosen remodeling actions and saves edited files under `downloads/files/`.
+1. **Analyse** – `remod_cli.py analyze` computes baseline statistics for a set of SWC files and writes them to `downloads/statistics/`.
+2. **Modify** – `remod_cli.py edit` applies the chosen remodeling actions and saves edited files under `downloads/files/`.
 3. **Reassign indices** – node indices are automatically renumbered after modifications.
-4. **Visualise and plot** – generate 3‑D views with `neuron_visualization.py` or `graph.py` and create summary plots with `plot_data.py`.
-5. **Combine statistics** – `merge_stats.py` merges and compares statistics from different runs.
+4. **Visualise and plot** – generate 3‑D views with `neuron_export.py` or `overlay_graph.py` and create summary plots with `plot_statistics.py`.
+5. **Combine statistics** – `merge_statistics.py` merges and compares statistics from different runs.
 
 ## More tools
 
-- `index_reassignment.py` contains the logic used to renumber nodes after editing.
-- `utils.py` provides weighted dendrite sampling utilities and warning helpers once kept in `warn.py`.
-- `take_action.py` implements the individual remodeling operations.
+- `reassign_indices.py` contains the logic used to renumber nodes after editing.
+- `core_utils.py` provides weighted dendrite sampling utilities and warning helpers once kept in `warn.py`.
+- `remodeling_actions.py` implements the individual remodeling operations.
 
 Run any script with the `--help` flag for a description of its command line options.

--- a/core_utils.py
+++ b/core_utils.py
@@ -94,7 +94,7 @@ def remove_empty_keys(data):
 
 
 def parse_plot_args(args: list[str] | None = None):
-    """Return parsed CLI options for :mod:`plot_data`-style scripts."""
+    """Return parsed CLI options for :mod:`plot_statistics`-style scripts."""
     parser = argparse.ArgumentParser(
         description="Generate summary plots from statistics files."
     )
@@ -115,7 +115,7 @@ def parse_plot_args(args: list[str] | None = None):
 
 
 def parse_analyze_args(args: list[str] | None = None):
-    """Return parsed CLI options for :mod:`run` analyze commands."""
+    """Return parsed CLI options for :mod:`remod_cli` analyze commands."""
     parser = argparse.ArgumentParser(
         description="Compute morphometric statistics for SWC files.",
     )
@@ -135,7 +135,7 @@ def parse_analyze_args(args: list[str] | None = None):
 
 
 def parse_edit_args(args: list[str] | None = None):
-    """Return parsed CLI options for :mod:`run` edit commands."""
+    """Return parsed CLI options for :mod:`remod_cli` edit commands."""
     parser = argparse.ArgumentParser(
         description="Apply remodeling actions to a SWC file.",
     )
@@ -183,7 +183,7 @@ def parse_edit_args(args: list[str] | None = None):
 
 
 def parse_merge_args(args: list[str] | None = None):
-    """Return parsed CLI options for :mod:`merge_stats` commands."""
+    """Return parsed CLI options for :mod:`merge_statistics` commands."""
     parser = argparse.ArgumentParser(
         description="Merge statistic files from different runs",
     )

--- a/file_io.py
+++ b/file_io.py
@@ -5,7 +5,7 @@ import json
 import re
 from typing import Iterable, Sequence
 
-from utils import ensure_dir
+from core_utils import ensure_dir
 
 
 def write_json(path: Path | str, data) -> None:

--- a/merge_statistics.py
+++ b/merge_statistics.py
@@ -6,15 +6,15 @@ from itertools import zip_longest
 from pathlib import Path
 import os
 
-from plot_data import plot_compare_data
-from file_utils import (
+from plot_statistics import plot_compare_data
+from file_io import (
     list_text_files,
     read_lines,
     read_sanitised_lines,
     zero_pad,
     zero_line,
 )
-from utils import ensure_dir, parse_merge_args
+from core_utils import ensure_dir, parse_merge_args
 
 
 

--- a/morphology_statistics.py
+++ b/morphology_statistics.py
@@ -6,7 +6,7 @@ from collections import OrderedDict, Counter, defaultdict
 from numpy import linalg as LA
 
 import numpy as np
-from utils import distance
+from core_utils import distance
 
 
 def _soma_coords(soma_samples):

--- a/neuron_export.py
+++ b/neuron_export.py
@@ -6,7 +6,7 @@ from itertools import chain
 from pathlib import Path
 from typing import Dict, Iterable, Iterator, List, Sequence
 
-from file_utils import write_lines
+from file_io import write_lines
 
 
 Color = str

--- a/overlay_graph.py
+++ b/overlay_graph.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from file_utils import write_plot
+from file_io import write_plot
 
 # ``plot_segments`` originally provided :func:`build_plot_from_lines` and the
 # ``PlotEntry`` alias.  They are now defined here to avoid a separate module.
@@ -15,8 +15,8 @@ PlotEntry = list[Sequence[float]]
 def build_plot_from_lines(lines: Iterable[str]) -> list[PlotEntry]:
     """Return plot segments for ``lines`` of an SWC file."""
 
-    from extract_swc_morphology import parse_swc_lines
-    from utils import round_to
+    from swc_parser import parse_swc_lines
+    from core_utils import round_to
 
     _, samples = parse_swc_lines(lines)
     plot: list[PlotEntry] = []

--- a/plot_statistics.py
+++ b/plot_statistics.py
@@ -16,8 +16,8 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-from utils import parse_plot_args
-from file_utils import (
+from core_utils import parse_plot_args
+from file_io import (
     read_value,
     read_values,
     read_single_value,
@@ -25,7 +25,7 @@ from file_utils import (
     read_compare_values,
     read_bulk_files,
 )
-from plot_utils import (
+from plotting_helpers import (
     BAR_A,
     BAR_B,
     FIG_SIZE,

--- a/plotting_helpers.py
+++ b/plotting_helpers.py
@@ -8,7 +8,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-from utils import ensure_dir
+from core_utils import ensure_dir
 
 
 BAR_A = "#406cbe"

--- a/reassign_indices.py
+++ b/reassign_indices.py
@@ -3,7 +3,7 @@
 The :func:`index_reassign` function updates the indices of all segments in the
 morphology so that they form a continuous sequence starting from 1.  It keeps
 the connectivity intact by adjusting the parent references of each segment. The
-function is used internally by ``run.py edit`` after dendrites have been
+function is used internally by ``remod_cli.py edit`` after dendrites have been
 removed, extended or otherwise modified.
 """
 

--- a/remod_cli.py
+++ b/remod_cli.py
@@ -7,10 +7,10 @@ import numpy as np
 import collections
 from pathlib import Path
 
-from extract_swc_morphology import *
+from swc_parser import *
 read_file = parse_swc_file
-from neuron_visualization import *
-from statistics_swc import (
+from neuron_export import *
+from morphology_statistics import (
     total_length,
     total_area,
     branch_order_frequency,
@@ -22,7 +22,7 @@ from statistics_swc import (
     sholl_intersections,
     branch_order,
 )
-from utils import (
+from core_utils import (
     round_to,
     average_list,
     average_dict,
@@ -34,11 +34,11 @@ from utils import (
     shrink_warning,
     check_indices,
 )
-from file_utils import write_json, write_value, write_swc, write_dict, write_pickle
-from statistics_swc import *
-from take_action import execute_action
-from graph import *
-from index_reassignment import *
+from file_io import write_json, write_value, write_swc, write_dict, write_pickle
+from morphology_statistics import *
+from remodeling_actions import execute_action
+from overlay_graph import *
+from reassign_indices import *
 
 def analyze_main(argv=None):
         """Compute morphometric statistics for one or more SWC files."""
@@ -442,7 +442,7 @@ def analyze_main(argv=None):
                                 pass
                         vector.append(sholl_apical_intersections[length])
         
-                from plot_data import plot_the_data
+                from plot_statistics import plot_the_data
                 prefix = stats_dir / f'{file_name}_'
                 plot_the_data(prefix)
         
@@ -767,7 +767,7 @@ def analyze_main(argv=None):
         f_average_sholl_apical_intersections=os.path.join(stats_dir, 'average_sholl_apical_intersections.txt')
         write_dict(f_average_sholl_apical_intersections, average_sholl_apical_intersections)
         
-        from plot_data import plot_average_data
+        from plot_statistics import plot_average_data
         prefix=os.path.join(stats_dir, 'average_')
         plot_average_data(prefix)
         
@@ -903,7 +903,7 @@ def edit_main(argv=None):
         
         print('\nSWC parsing is completed!\n')
         
-        #from graph import *
+        #from overlay_graph import *
         #local_plot(swc_lines)
         
         #regex_who=re.search('(.*)', choices[0])
@@ -1016,7 +1016,7 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     if not argv:
-        print("Usage: run.py <analyze|edit> [options]")
+        print("Usage: remod_cli.py <analyze|edit> [options]")
         return
 
     command, *sub_args = argv

--- a/remodeling_actions.py
+++ b/remodeling_actions.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, Iterable, List, Tuple
 
 import numpy as np
 from math import cos, sin, radians
-from utils import distance, round_to
-from file_utils import read_lines
+from core_utils import distance, round_to
+from file_io import read_lines
 
 def parse_length_distribution(
     path: Path = Path("length_distribution.txt"),
@@ -908,7 +908,7 @@ def scale(target_dendrites, soma_samples, dendrite_samples, amount):
         return new_lines
 
 # ---------------------------------------------------------------------------
-# Dispatcher originally implemented in ``take_action.py``
+# Dispatcher originally implemented in ``remodeling_actions.py``
 # ---------------------------------------------------------------------------
 
 ActionFunc = Callable[[], List[str]]

--- a/swc_parser.py
+++ b/swc_parser.py
@@ -6,13 +6,13 @@ from pathlib import Path
 
 import numpy as np
 
-from utils import distance
-from file_utils import read_lines
+from core_utils import distance
+from file_io import read_lines
 
 
 def read_swc_lines(file_path: str) -> List[str]:
     """Return all lines from *file_path* without trailing newlines."""
-    # Use the helper from :mod:`file_utils` for consistency
+    # Use the helper from :mod:`file_io` for consistency
     return read_lines(Path(file_path))
 
 def parse_swc_lines(swc_lines: Iterable[str]) -> Tuple[List[str], Dict[int, List[float]]]:


### PR DESCRIPTION
## Summary
- rename run.py to remod_cli.py and update imports
- rename helper modules for clarity
- update README instructions
- update gitignore for renamed files

## Testing
- `python -m py_compile $(git ls-files '*.py')`