### PR TITLE
Wrap helpers in lightweight classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,12 @@ The typical pipeline is:
 - `plot_statistics.py` now includes the plotting helpers previously found in `plotting_helpers.py`.
 - `swc_parser.py` exposes an `SWCParser` class wrapping the old `parse_swc_file` function.
 - `logger_utils.py` features a small `MarkdownLogger` for writing logs.
+- `core_utils.py` collects CLI parsers in the `CLIParsers` class.
+- Common file helpers live under `FileIO` in `file_io.py`.
+- Morphometric functions are grouped inside `MorphologyStats`.
+- `json_stats.py` exports a `StatisticsComputer` for JSON output.
+- Plotting helpers are available via the `StatisticsPlotter` class.
+- The main entry points reside in `RemodCLI` within `remod_cli.py`.
+- Remodeling actions are accessible through the `RemodelActions` class.
 
 Run any script with the `--help` flag for a description of its command line options.

--- a/core_utils.py
+++ b/core_utils.py
@@ -254,3 +254,13 @@ __all__ = [
     "shrink_warning",
     "check_indices",
 ]
+
+
+class CLIParsers:
+    """Class-based accessors for the CLI parsing helpers."""
+
+    parse_plot_args = staticmethod(parse_plot_args)
+    parse_analyze_args = staticmethod(parse_analyze_args)
+    parse_edit_args = staticmethod(parse_edit_args)
+    parse_merge_args = staticmethod(parse_merge_args)
+

--- a/file_io.py
+++ b/file_io.py
@@ -350,3 +350,27 @@ def graph(
     write_plot(fname, before_plot, after_plot)
 
 
+class FileIO:
+    """Convenient namespace for common file helpers."""
+
+    write_json = staticmethod(write_json)
+    write_value = staticmethod(write_value)
+    read_values = staticmethod(read_values)
+    read_value = staticmethod(read_value)
+    list_text_files = staticmethod(list_text_files)
+    read_lines = staticmethod(read_lines)
+    zero_line = staticmethod(zero_line)
+    read_sanitised_lines = staticmethod(read_sanitised_lines)
+    zero_pad = staticmethod(zero_pad)
+    write_swc = staticmethod(write_swc)
+    write_lines = staticmethod(write_lines)
+    write_dict = staticmethod(write_dict)
+    write_plot = staticmethod(write_plot)
+    read_single_value = staticmethod(read_single_value)
+    read_table_data = staticmethod(read_table_data)
+    read_compare_values = staticmethod(read_compare_values)
+    read_bulk_files = staticmethod(read_bulk_files)
+    write_pickle = staticmethod(write_pickle)
+    build_plot_from_lines = staticmethod(build_plot_from_lines)
+    graph = staticmethod(graph)
+

--- a/json_stats.py
+++ b/json_stats.py
@@ -146,3 +146,10 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":
     main()
+
+
+class StatisticsComputer:
+    """Class wrapper around :func:`compute_statistics` and :func:`main`."""
+
+    compute_statistics = staticmethod(compute_statistics)
+    main = staticmethod(main)

--- a/morphology_statistics.py
+++ b/morphology_statistics.py
@@ -164,3 +164,19 @@ __all__ = [
     "sholl_length",
 ]
 
+
+class MorphologyStats:
+    """Namespace for morphometric statistic helpers."""
+
+    total_length = staticmethod(total_length)
+    total_area = staticmethod(total_area)
+    path_length = staticmethod(path_length)
+    median_radius = staticmethod(median_radius)
+    branch_order_frequency = staticmethod(branch_order_frequency)
+    branch_order_dlength = staticmethod(branch_order_dlength)
+    branch_order_path_length = staticmethod(branch_order_path_length)
+    sholl_intersections = staticmethod(sholl_intersections)
+    sholl_branch_points = staticmethod(sholl_branch_points)
+    remove_trailing_zeros = staticmethod(remove_trailing_zeros)
+    sholl_length = staticmethod(sholl_length)
+

--- a/plot_statistics.py
+++ b/plot_statistics.py
@@ -216,6 +216,16 @@ __all__ = [
     "merge_smart",
 ]
 
+
+class StatisticsPlotter:
+    """Class-based wrapper around the plotting utilities."""
+
+    plot_the_data = staticmethod(plot_the_data)
+    plot_average_data = staticmethod(plot_average_data)
+    plot_compare_data = staticmethod(plot_compare_data)
+    merge_simple = staticmethod(merge_simple)
+    merge_smart = staticmethod(merge_smart)
+
 COMPARE_OTHER = [
     (
         "compare_total_number_of_branchpoints.svg",

--- a/remod_cli.py
+++ b/remod_cli.py
@@ -1045,3 +1045,11 @@ def main(argv=None):
 
 if __name__ == '__main__':
     main()
+
+
+class RemodCLI:
+    """Callable interface to the ``remod_cli`` entry points."""
+
+    analyze_main = staticmethod(analyze_main)
+    edit_main = staticmethod(edit_main)
+    main = staticmethod(main)

--- a/remodeling_actions.py
+++ b/remodeling_actions.py
@@ -1041,3 +1041,20 @@ def execute_action(
         )
 
     return new_lines, dendrite_roots, sample_list
+
+
+class RemodelActions:
+    """Container class for the remodeling action helpers."""
+
+    parse_length_distribution = staticmethod(parse_length_distribution)
+    select_length = staticmethod(select_length)
+    create_points = staticmethod(create_points)
+    add_random_point = staticmethod(add_random_point)
+    translate_descendants = staticmethod(translate_descendants)
+    allocate_new_dendrites = staticmethod(allocate_new_dendrites)
+    extend_dendrite = staticmethod(extend_dendrite)
+    shrink = staticmethod(shrink)
+    remove = staticmethod(remove)
+    extend = staticmethod(extend)
+    radius_change = staticmethod(radius_change)
+    execute_action = staticmethod(execute_action)


### PR DESCRIPTION
## Summary
- group CLI helpers under `CLIParsers`
- expose I/O utilities through `FileIO`
- export `StatisticsComputer`, `MorphologyStats`, `StatisticsPlotter`, `RemodCLI` and `RemodelActions`
- document the new class based interfaces in the README

## Testing
- `python -m py_compile *.py`