### PR TITLE
Fix create_points axis check

### DIFF
--- a/remodeling_actions.py
+++ b/remodeling_actions.py
@@ -60,7 +60,9 @@ def create_points(
     rotation_angle = radians(angle)
 
     axis_origin = [0, 0, 1]
-    if end_point[0] == end_point[0] and end_point[1] == start_point[1]:
+    # use Y as the rotation axis when the segment lies along X
+    # and Y directions to avoid numerical issues
+    if end_point[0] == start_point[0] and end_point[1] == start_point[1]:
         axis_origin = [0, 1, 0]
 
     start_matrix = np.matrix([float(start_point[0]), float(start_point[1]), float(start_point[2])])


### PR DESCRIPTION
## Summary
- correct create_points axis check when determining reference axis

## Testing
- `python -m py_compile core_utils.py file_io.py json_stats.py logger_utils.py morphology_statistics.py plot_statistics.py remod_cli.py remodeling_actions.py swc_parser.py`