### PR TITLE
Fix renumbering bug in dendrite parser

### DIFF
--- a/swc_parser.py
+++ b/swc_parser.py
@@ -430,7 +430,7 @@ def _renumber_dendrite(
 
         previous = start_index
         start_index += 1
-    samples.append(point)
+        samples.append(point)
 
     return start_index
 


### PR DESCRIPTION
## Summary
- fix `_renumber_dendrite` so every renumbered sample is stored

## Testing
- `python -m py_compile *.py`